### PR TITLE
add C-API SendMessageOneway

### DIFF
--- a/include/CProducer.h
+++ b/include/CProducer.h
@@ -47,7 +47,7 @@ int SetProducerCompressLevel(CProducer *producer, int level);
 int SetProducerMaxMessageSize(CProducer *producer, int size);
 
 int SendMessageSync(CProducer *producer, CMessage *msg, CSendResult *result);
-
+int SendMessageOneway(CProducer *producer,CMessage *msg);
 #ifdef __cplusplus
 };
 #endif

--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -93,6 +93,16 @@ int SendMessageSync(CProducer *producer, CMessage *msg, CSendResult *result) {
     return OK;
 }
 
+int SendMessageOneway(CProducer *producer,CMessage *msg) {
+    if (producer == NULL || msg == NULL) {
+        return NULL_POINTER;
+    }
+    DefaultMQProducer *defaultMQProducer = (DefaultMQProducer *) producer;
+    MQMessage *message = (MQMessage *) msg;
+    defaultMQProducer->sendOneway(*message);
+    return OK;
+}
+
 int SetProducerGroupName(CProducer *producer, const char *groupName) {
     if (producer == NULL) {
         return NULL_POINTER;


### PR DESCRIPTION
What is the purpose of the change

Add add C-API SendMessageOneway.

Brief changelog

The definition of SendMessageOneway interface is added to the CProducer.h  .
The SendMessageOneway interface is implemented in the  CProducer.cpp.