### PR TITLE
Update build.sh and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,21 @@ doc/rocketmq-cpp_manaual_zh.docx
 **note**: *make sure the following compile tools or libraries with them minimum version number have been installed before run the build script build.sh*
 
 - compile tools:
-	- gcc-c++ 4.8.2: jsoncpp,boost rocket-client require it, need support C++11
-	- cmake 2.8.0: jsoncpp,rocketmq-client require it
-	- automake 1.11.1: libevent require it
-	- libtool 2.2.6: libevent require it
+	- gcc-c++ 4.8.2: c++ compiler while need support C++11
+	- cmake 2.8.0: build jsoncpp require it
+	- automake 1.11.1: build libevent require it
+	- libtool 2.2.6: build libevent require it
 
 - libraries:   
-	- bzip2-devel 1.0.6: boost dependcy it
+	- bzip2-devel 1.0.6: boost depend it
 
-one key build script will automatic build the dependency libraries include libevent json and boost, then it will build rocketmq-client static and shared library.
+build.sh script will automatic build the dependency libraries include libevent json and boost, then it will build rocketmq-client static and shared library.
 
-if can't get internet to download three library source files by build script, you can copy three library source files (release-2.0.22-stable.zip  0.10.6.zip and boost_1_56_0.tar.gz) to rocketmq-client root dir, then build.sh will auto use these library files to build rocketmq-client.
+if you can't get to internet to download three library source files by build.sh script, you can copy three library source files (release-2.0.22-stable.zip  0.10.6.zip and boost_1_58_0.tar.gz) to rocketmq-client-cpp root dir, then build.sh will auto use these three library source files to build rocketmq-client-cpp.
 
     sudo sh build.sh
 
-then there are librocketmq.a and librocketmq.so in /usr/local/lib. for use them to build application you should link with following libraries: -lrocketmq -lpthread -lz -ldl -lrt.
+then there are both librocketmq.a and librocketmq.so in /usr/local/lib. when use them to build application or library you should link with following libraries: -lrocketmq -lpthread -lz -ldl -lrt.
 
     g++ -o consumer_example consumer_example.cpp -L. -lrocketmq -lpthread -lz -ldl -lrt
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RocketMQ-Client-CPP is the C/C++ client of Apache RocketMQ which is a distribute
 
 - [jsoncpp 0.10.6](https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.zip  "jsoncpp 0.10.6")
 
-- [boost 1.56.0](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz "boost 1.56.0")
+- [boost 1.58.0](http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz "boost 1.58.0")
 
 ## Documentation ##
 doc/rocketmq-cpp_manaual_zh.docx
@@ -71,7 +71,7 @@ download [cmake windows tool](https://cmake.org/files/v3.9/cmake-3.9.3-win64-x64
 run cmake-gui.exe, choose your source code dir and build dir, then click generate which will let you choose Virtual Studio version
 open project by VirtualStudio, and build jsoncpp, and jsoncpp.lib will be got
 
-1. install [boost 1.56.0](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz "boost 1.56.0")
+1. install [boost 1.58.0](http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz "boost 1.58.0")
 according to following discription: http://www.boost.org/doc/libs/1_56_0/more/getting_started/windows.html
 following build options are needed to be set when run bjam.exe: msvc architecture=x86 address-model=64 link=static runtime-link=static stage
 all lib will be generated except boost_zlib:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RocketMQ-Client-CPP is the C/C++ client of Apache RocketMQ which is a distribute
 
 - [jsoncpp 0.10.6](https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.zip  "jsoncpp 0.10.6")
 
-- [boost 1.58.0](http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz "boost 1.58.0")
+- [boost 1.56.0](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz "boost 1.56.0")
 
 ## Documentation ##
 doc/rocketmq-cpp_manaual_zh.docx
@@ -71,7 +71,7 @@ download [cmake windows tool](https://cmake.org/files/v3.9/cmake-3.9.3-win64-x64
 run cmake-gui.exe, choose your source code dir and build dir, then click generate which will let you choose Virtual Studio version
 open project by VirtualStudio, and build jsoncpp, and jsoncpp.lib will be got
 
-1. install [boost 1.58.0](http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz "boost 1.58.0")
+1. install [boost 1.56.0](http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz "boost 1.56.0")
 according to following discription: http://www.boost.org/doc/libs/1_56_0/more/getting_started/windows.html
 following build options are needed to be set when run bjam.exe: msvc architecture=x86 address-model=64 link=static runtime-link=static stage
 all lib will be generated except boost_zlib:

--- a/build.sh
+++ b/build.sh
@@ -131,14 +131,29 @@ function BuildLibevent()
         wget https://github.com/libevent/libevent/archive/${fname_libevent_down} -O libevent-${fname_libevent_down}
     fi
     unzip -o ${fname_libevent}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
+
     libevent_dir=`ls | grep libevent | grep .*[^zip]$`
     echo ${libevent_dir}
     cd ${libevent_dir}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi    
     ./autogen.sh
-
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     echo "build libevent static #####################"
     ./configure --disable-openssl --enable-static=yes --enable-shared=no CFLAGS=-fPIC CPPFLAGS=-fPIC
+    if [ $? -ne 0 ];then
+        exit 1
+    fi    
     make
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     sudo make install
 }
 
@@ -159,13 +174,24 @@ function BuildJsonCPP()
         wget https://github.com/open-source-parsers/jsoncpp/archive/${fname_jsoncpp_down} -O jsoncpp-${fname_jsoncpp_down}
     fi
     unzip -o ${fname_jsoncpp}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     jsoncpp_dir=`ls | grep ^jsoncpp | grep .*[^zip]$`
     cd ${jsoncpp_dir}
-
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     mkdir build; cd build
 	echo "build jsoncpp static #####################"
 	cmake .. -DCMAKE_CXX_FLAGS=-fPIC -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF
+    if [ $? -ne 0 ];then
+        exit 1
+    fi    
     make
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     sudo make install
 }
 
@@ -181,14 +207,23 @@ function BuildBoost()
     then
         echo "${fname_boost} is exist"
     else
-        wget http://sourceforge.net/projects/boost/files/boost/1.58.0/${fname_boost_down}
+        wget http://sourceforge.net/projects/boost/files/boost/${fname_boost_down}
     fi
     tar -zxvf ${fname_boost}
     boost_dir=`ls | grep boost | grep .*[^gz]$`
-    cd {boost_dir}
+    cd ${boost_dir}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
     ./bootstrap.sh
+    if [ $? -ne 0 ];then
+        exit 1
+    fi    
     echo "build boost static #####################"
     sudo ./b2 cflags=-fPIC cxxflags=-fPIC --with-atomic --with-thread --with-system --with-chrono --with-date_time --with-log --with-regex --with-serialization --with-filesystem --with-locale --with-iostreams threading=multi link=static runtime-link=static release install
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
 }
 
 function BuildRocketMQClient()
@@ -196,6 +231,9 @@ function BuildRocketMQClient()
     cd ${build_dir}
     cmake ..
     make
+    if [ $? -ne 0 ];then
+        exit 1
+    fi        
     sudo make install
 	
     PackageRocketMQStatic

--- a/build.sh
+++ b/build.sh
@@ -181,7 +181,7 @@ function BuildBoost()
     then
         echo "${fname_boost} is exist"
     else
-        wget http://sourceforge.net/projects/boost/files/boost/1.58.0/${fname_boost_down}
+        wget http://sourceforge.net/projects/boost/files/boost/${fname_boost_down}
     fi
     tar -zxvf ${fname_boost}
     boost_dir=`ls | grep boost | grep .*[^gz]$`

--- a/build.sh
+++ b/build.sh
@@ -181,7 +181,7 @@ function BuildBoost()
     then
         echo "${fname_boost} is exist"
     else
-        wget http://sourceforge.net/projects/boost/files/boost/${fname_boost_down}
+        wget http://sourceforge.net/projects/boost/files/boost/1.58.0/${fname_boost_down}
     fi
     tar -zxvf ${fname_boost}
     boost_dir=`ls | grep boost | grep .*[^gz]$`

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,12 @@ build_dir="${basepath}/tmp_build_dir"
 packet_dir="${basepath}/tmp_packet_dir"
 sys_lib_dir="/usr/local/lib"
 bin_dir="${basepath}/bin"
-fname_libevent="release-2.0.22-stable.zip"
-fname_jsoncpp="0.10.6.zip"
-fname_boost="boost_1_58_0.tar.gz"
+fname_libevent="libevent*.zip"
+fname_jsoncpp="jsoncpp*.zip"
+fname_boost="boost*.tar.gz"
+fname_libevent_down="release-2.0.22-stable.zip"
+fname_jsoncpp_down="0.10.6.zip"
+fname_boost_down="1.58.0/boost_1_58_0.tar.gz"
 
 function Help()
 {
@@ -125,10 +128,12 @@ function BuildLibevent()
     then
         echo "${fname_libevent} is exist"
     else
-        wget https://github.com/libevent/libevent/archive/${fname_libevent}
+        wget https://github.com/libevent/libevent/archive/${fname_libevent_down} -O libevent-${fname_libevent_down}
     fi
-    unzip ${fname_libevent}
-    cd libevent-release-2.0.22-stable
+    unzip -o ${fname_libevent}
+    libevent_dir=`ls | grep libevent | grep .*[^zip]$`
+    echo ${libevent_dir}
+    cd ${libevent_dir}
     ./autogen.sh
 
     echo "build libevent static #####################"
@@ -151,10 +156,11 @@ function BuildJsonCPP()
     then
         echo "${fname_jsoncpp} is exist"
     else
-        wget https://github.com/open-source-parsers/jsoncpp/archive/${fname_jsoncpp}
+        wget https://github.com/open-source-parsers/jsoncpp/archive/${fname_jsoncpp_down} -O jsoncpp-${fname_jsoncpp_down}
     fi
-    unzip ${fname_jsoncpp}
-    cd jsoncpp-0.10.6
+    unzip -o ${fname_jsoncpp}
+    jsoncpp_dir=`ls | grep ^jsoncpp | grep .*[^zip]$`
+    cd ${jsoncpp_dir}
 
     mkdir build; cd build
 	echo "build jsoncpp static #####################"
@@ -175,10 +181,11 @@ function BuildBoost()
     then
         echo "${fname_boost} is exist"
     else
-        wget http://sourceforge.net/projects/boost/files/boost/1.58.0/${fname_boost}
+        wget http://sourceforge.net/projects/boost/files/boost/1.58.0/${fname_boost_down}
     fi
     tar -zxvf ${fname_boost}
-    cd boost_1_58_0
+    boost_dir=`ls | grep boost | grep .*[^gz]$`
+    cd {boost_dir}
     ./bootstrap.sh
     echo "build boost static #####################"
     sudo ./b2 cflags=-fPIC cxxflags=-fPIC --with-atomic --with-thread --with-system --with-chrono --with-date_time --with-log --with-regex --with-serialization --with-filesystem --with-locale --with-iostreams threading=multi link=static runtime-link=static release install

--- a/src/producer/StringIdMaker.h
+++ b/src/producer/StringIdMaker.h
@@ -11,11 +11,16 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
 #include <time.h>
-#include <unistd.h>
 #include <boost/serialization/singleton.hpp>
 #include <string>
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <sys/time.h>
+#endif
 
 namespace rocketmq {
 class StringIdMaker : public boost::serialization::singleton<StringIdMaker> {


### PR DESCRIPTION
1、update boost version from 1.56 to 1.58
2、add exist script when build error of build.sh
3、resolve a bug for build.sh when user copy boost/jsoncpp/libevent source files to rocketmq-client-cpp other then download them by build.sh