### PR TITLE
Upgrade libevent version to 2.1.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ install_lib_dir="${basepath}/bin"
 fname_libevent="libevent*.zip"
 fname_jsoncpp="jsoncpp*.zip"
 fname_boost="boost*.tar.gz"
-fname_libevent_down="release-2.0.22-stable.zip"
+fname_libevent_down="release-2.1.8-stable.zip"
 fname_jsoncpp_down="0.10.6.zip"
 fname_boost_down="1.58.0/boost_1_58_0.tar.gz"
 


### PR DESCRIPTION
On my latest macOS(10.14.1), a warning message occurs:
 ```[warn] kq_init: detected broken kqueue; not using.: Undefined error: 0```
according to [issue from libevent](https://github.com/libevent/libevent/issues/376), it was fixed as of version 2.1.8. So I send this pull request.