### PR TITLE
fix warning while compiling rocketmq_static

### DIFF
--- a/src/MQClientAPIImpl.cpp
+++ b/src/MQClientAPIImpl.cpp
@@ -152,7 +152,7 @@ string MQClientAPIImpl::fetchNameServerAddr(const string& NSDomain) {
       // update the snapshot local file if nameSrv changes or
       // m_firstFetchNameSrv==true
       if (writeDataToFile(fileBak, addrs, true)) {
-        if (UtilAll::ReplaceFile(fileBak, file) == -1)
+        if (!UtilAll::ReplaceFile(fileBak, file))
           LOG_ERROR("could not rename bak file:%s", strerror(errno));
       }
     }
@@ -160,7 +160,7 @@ string MQClientAPIImpl::fetchNameServerAddr(const string& NSDomain) {
     if (!boost::filesystem::exists(snapshot_file)) {
       // the name server snapshot local file maybe deleted by force, create it
       if (writeDataToFile(fileBak, m_nameSrvAddr, true)) {
-        if (UtilAll::ReplaceFile(fileBak, file) == -1)
+        if (!UtilAll::ReplaceFile(fileBak, file))
           LOG_ERROR("could not rename bak file:%s", strerror(errno));
       }
     }

--- a/src/consumer/OffsetStore.cpp
+++ b/src/consumer/OffsetStore.cpp
@@ -214,7 +214,7 @@ void LocalFileOffsetStore::persistAll(const std::vector<MQMessageQueue>& mqs) {
                         "persistAll:open offset store file failed", -1);
     }
     s.close();
-    if (UtilAll::ReplaceFile(storefile_bak, m_storeFile) == -1)
+    if (!UtilAll::ReplaceFile(storefile_bak, m_storeFile))
       LOG_ERROR("could not rename bak file:%s", strerror(errno));
     m_offsetTable_tmp.clear();
   } else {

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -244,7 +244,7 @@ void DefaultMQProducer::setMaxMessageSize(int maxMessageSize) {
 int DefaultMQProducer::getCompressLevel() const { return m_compressLevel; }
 
 void DefaultMQProducer::setCompressLevel(int compressLevel) {
-  assert(compressLevel >= 0 && compressLevel <= 9 || compressLevel == -1);
+  assert((compressLevel >= 0 && compressLevel <= 9) || compressLevel == -1);
 
   m_compressLevel = compressLevel;
 }


### PR DESCRIPTION
1. the return value of "UtilAll::ReplaceFile" is bool, not integer.
2. gcc suggest parentheses around '&&' within '||'。