### PR TITLE
[Issue#44] Resolve RetrySendTimes doesn't Work for Async Send

### DIFF
--- a/include/DefaultMQProducer.h
+++ b/include/DefaultMQProducer.h
@@ -76,6 +76,9 @@ class ROCKETMQCLIENT_API DefaultMQProducer : public MQProducer {
   int getRetryTimes() const;
   void setRetryTimes(int times);
 
+  int getRetryTimes4Async() const;
+  void setRetryTimes4Async(int times);
+
  protected:
   SendResult sendAutoRetrySelectImpl(MQMessage& msg,
                                      MessageQueueSelector* pSelector,
@@ -100,6 +103,7 @@ class ROCKETMQCLIENT_API DefaultMQProducer : public MQProducer {
   bool m_retryAnotherBrokerWhenNotStoreOK;
   int m_compressLevel;
   int m_retryTimes;
+  int m_retryTimes4Async;  
 };
 //<!***************************************************************************
 }  //<!end namespace;

--- a/src/MQClientAPIImpl.cpp
+++ b/src/MQClientAPIImpl.cpp
@@ -420,27 +420,27 @@ void MQClientAPIImpl::sendMessageAsync(const string& addr,
   LOG_DEBUG("sendMessageAsync request:%s, timeout:%lld, maxRetryTimes:%d retrySendTimes:%d", request.ToString().data(), timeoutMilliseconds, maxRetryTimes, retrySendTimes);
   
   if (m_pRemotingClient->invokeAsync(addr, request, cbw, timeoutMilliseconds, maxRetryTimes, retrySendTimes) ==
-      false) {
+    false) {
     LOG_WARN("invokeAsync failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
-		addr.c_str(), msg.getTopic().data(), timeoutMilliseconds, maxRetryTimes, retrySendTimes);
-	//when getTcp return false, need consider retrySendTimes
-	int retry_time = retrySendTimes + 1;
-	int64 time_out = timeoutMilliseconds - (UtilAll::currentTimeMillis() - begin_time);
-	while (retry_time < maxRetryTimes && time_out > 0) {
-		begin_time = UtilAll::currentTimeMillis();
-		if (m_pRemotingClient->invokeAsync(addr, request, cbw, time_out, maxRetryTimes, retry_time) == false) {
-			retry_time += 1;
-			time_out = time_out - (UtilAll::currentTimeMillis() - begin_time);
-			LOG_WARN("invokeAsync retry failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
+	  addr.c_str(), msg.getTopic().data(), timeoutMilliseconds, maxRetryTimes, retrySendTimes);
+	  //when getTcp return false, need consider retrySendTimes
+	  int retry_time = retrySendTimes + 1;
+	  int64 time_out = timeoutMilliseconds - (UtilAll::currentTimeMillis() - begin_time);
+	  while (retry_time < maxRetryTimes && time_out > 0) {
+		  begin_time = UtilAll::currentTimeMillis();
+		  if (m_pRemotingClient->invokeAsync(addr, request, cbw, time_out, maxRetryTimes, retry_time) == false) {
+		    retry_time += 1;
+		    time_out = time_out - (UtilAll::currentTimeMillis() - begin_time);
+			  LOG_WARN("invokeAsync retry failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
 				addr.c_str(), msg.getTopic().data(), time_out, maxRetryTimes, retry_time);
-			continue;
-		} else {
-			return; //invokeAsync success
-		}
-	}
+			  continue;
+		  } else {
+			  return; //invokeAsync success
+		  }
+	  }
 
     LOG_ERROR("sendMessageAsync failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
-		addr.c_str(), msg.getTopic().data(), time_out, maxRetryTimes, retrySendTimes);
+	  addr.c_str(), msg.getTopic().data(), time_out, maxRetryTimes, retrySendTimes);
 
     if (cbw) {
       cbw->onException();

--- a/src/MQClientAPIImpl.cpp
+++ b/src/MQClientAPIImpl.cpp
@@ -217,7 +217,7 @@ void MQClientAPIImpl::createTopic(
 
 SendResult MQClientAPIImpl::sendMessage(
     const string& addr, const string& brokerName, const MQMessage& msg,
-    SendMessageRequestHeader* pRequestHeader, int timeoutMillis,
+    SendMessageRequestHeader* pRequestHeader, int timeoutMillis, int maxRetrySendTimes,
     int communicationMode, SendCallback* pSendCallback,
     const SessionCredentials& sessionCredentials) {
   RemotingCommand request(SEND_MESSAGE, pRequestHeader);
@@ -232,8 +232,7 @@ SendResult MQClientAPIImpl::sendMessage(
       m_pRemotingClient->invokeOneway(addr, request);
       break;
     case ComMode_ASYNC:
-      sendMessageAsync(addr, brokerName, msg, request, pSendCallback,
-                       timeoutMillis);
+      sendMessageAsync(addr, brokerName, msg, request, pSendCallback, timeoutMillis, maxRetrySendTimes, 1);
       break;
     case ComMode_SYNC:
       return sendMessageSync(addr, brokerName, msg, request, timeoutMillis);
@@ -411,13 +410,38 @@ void MQClientAPIImpl::sendMessageAsync(const string& addr,
                                        const MQMessage& msg,
                                        RemotingCommand& request,
                                        SendCallback* pSendCallback,
-                                       int64 timeoutMilliseconds) {
+                                       int64 timeoutMilliseconds,
+                                       int maxRetryTimes,
+                                       int retrySendTimes) {
+  int64 begin_time = UtilAll::currentTimeMillis();
   //<!delete in future;
-  AsyncCallbackWrap* cbw =
-      new SendCallbackWrap(brokerName, msg, pSendCallback, this);
-  if (m_pRemotingClient->invokeAsync(addr, request, cbw, timeoutMilliseconds) ==
+  AsyncCallbackWrap* cbw = new SendCallbackWrap(brokerName, msg, pSendCallback, this);
+
+  LOG_DEBUG("sendMessageAsync request:%s, timeout:%lld, maxRetryTimes:%d retrySendTimes:%d", request.ToString().data(), timeoutMilliseconds, maxRetryTimes, retrySendTimes);
+  
+  if (m_pRemotingClient->invokeAsync(addr, request, cbw, timeoutMilliseconds, maxRetryTimes, retrySendTimes) ==
       false) {
-    LOG_ERROR("sendMessageAsync failed to addr:%s", addr.c_str());
+    LOG_WARN("invokeAsync failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
+		addr.c_str(), msg.getTopic().data(), timeoutMilliseconds, maxRetryTimes, retrySendTimes);
+	//when getTcp return false, need consider retrySendTimes
+	int retry_time = retrySendTimes + 1;
+	int64 time_out = timeoutMilliseconds - (UtilAll::currentTimeMillis() - begin_time);
+	while (retry_time < maxRetryTimes && time_out > 0) {
+		begin_time = UtilAll::currentTimeMillis();
+		if (m_pRemotingClient->invokeAsync(addr, request, cbw, time_out, maxRetryTimes, retry_time) == false) {
+			retry_time += 1;
+			time_out = time_out - (UtilAll::currentTimeMillis() - begin_time);
+			LOG_WARN("invokeAsync retry failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
+				addr.c_str(), msg.getTopic().data(), time_out, maxRetryTimes, retry_time);
+			continue;
+		} else {
+			return; //invokeAsync success
+		}
+	}
+
+    LOG_ERROR("sendMessageAsync failed to addr:%s,topic:%s, timeout:%lld, maxRetryTimes:%d, retrySendTimes:%d", 
+		addr.c_str(), msg.getTopic().data(), time_out, maxRetryTimes, retrySendTimes);
+
     if (cbw) {
       cbw->onException();
       deleteAndZero(cbw);

--- a/src/MQClientAPIImpl.h
+++ b/src/MQClientAPIImpl.h
@@ -60,7 +60,8 @@ class MQClientAPIImpl {
   SendResult sendMessage(const string& addr, const string& brokerName,
                          const MQMessage& msg,
                          SendMessageRequestHeader* pRequestHeader,
-                         int timeoutMillis, int communicationMode,
+                         int timeoutMillis, int maxRetrySendTimes,
+                         int communicationMode,
                          SendCallback* pSendCallback,
                          const SessionCredentials& sessionCredentials);
 
@@ -161,15 +162,20 @@ class MQClientAPIImpl {
                      int timeoutMillis,
                      const SessionCredentials& sessionCredentials);
 
+  void sendMessageAsync(const string& addr, const string& brokerName,
+                        const MQMessage& msg, RemotingCommand& request,
+                        SendCallback* pSendCallback, int64 timeoutMilliseconds,
+                        int maxRetryTimes=1,
+                        int retrySendTimes=1);
  private:
   SendResult sendMessageSync(const string& addr, const string& brokerName,
                              const MQMessage& msg, RemotingCommand& request,
                              int timeoutMillis);
-
+  /*
   void sendMessageAsync(const string& addr, const string& brokerName,
                         const MQMessage& msg, RemotingCommand& request,
                         SendCallback* pSendCallback, int64 timeoutMilliseconds);
-
+  */
   PullResult* pullMessageSync(const string& addr, RemotingCommand& request,
                               int timeoutMillis);
 

--- a/src/common/AsyncCallbackWrap.h
+++ b/src/common/AsyncCallbackWrap.h
@@ -21,11 +21,14 @@
 #include "AsyncCallback.h"
 #include "MQMessage.h"
 #include "UtilAll.h"
+#include "RemotingCommand.h"
 
 namespace rocketmq {
 
 class ResponseFuture;
 class MQClientAPIImpl;
+class DefaultMQProducer;
+class SendMessageRequestHeader;
 //<!***************************************************************************
 enum asyncCallBackType {
   asyncCallbackWrap = 0,

--- a/src/protocol/RemotingCommand.cpp
+++ b/src/protocol/RemotingCommand.cpp
@@ -281,7 +281,7 @@ void RemotingCommand::addExtField(const string& key, const string& value) {
   m_extFields[key] = value;
 }
 
-std::string RemotingCommand::ToString() {
+std::string RemotingCommand::ToString() const {
 	 std::stringstream ss;
 	 ss << "code:" << m_code
 	  <<",opaque:"<< m_opaque

--- a/src/protocol/RemotingCommand.cpp
+++ b/src/protocol/RemotingCommand.cpp
@@ -51,46 +51,37 @@ RemotingCommand::RemotingCommand(int code, string language, int version,
       m_pExtHeader(pExtHeader) {}
 
 RemotingCommand::RemotingCommand(const RemotingCommand& command) {
-  m_code = command.m_code;
-  m_language = command.m_language;
-  m_version = command.m_version;
-  m_opaque = command.m_opaque;
-  m_flag = command.m_flag;
-  m_remark = command.m_remark;
-  m_msgBody = command.m_msgBody;
-  
-  for (auto& it : command.m_extFields) {
-	  m_extFields[it.first] = it.second;
-  }
-  m_head = command.m_head;
-  m_body = command.m_body;
-  s_seqNumber.store(command.s_seqNumber.load());
-  m_parsedJson = command.m_parsedJson;
-  //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
+    Assign(command);
 }
 
-
 RemotingCommand& RemotingCommand::operator=(const RemotingCommand& command) {
-  m_code = command.m_code;
-  m_language = command.m_language;
-  m_version = command.m_version;
-  m_opaque = command.m_opaque;
-  m_flag = command.m_flag;
-  m_remark = command.m_remark;
-  m_msgBody = command.m_msgBody;
-  
-  for (auto& it : command.m_extFields) {
-	  m_extFields[it.first] = it.second;
+  if (this != &command) {
+    Assign(command);
   }
-  m_head = command.m_head;
-  m_body = command.m_body;
-  s_seqNumber.store(command.s_seqNumber.load());
-  m_parsedJson = command.m_parsedJson;
-  //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
   return *this;
 }
 
 RemotingCommand::~RemotingCommand() { m_pExtHeader = NULL; }
+
+void RemotingCommand::Assign(const RemotingCommand& command)
+{
+    m_code = command.m_code;
+    m_language = command.m_language;
+    m_version = command.m_version;
+    m_opaque = command.m_opaque;
+    m_flag = command.m_flag;
+    m_remark = command.m_remark;
+    m_msgBody = command.m_msgBody;
+    
+    for (auto& it : command.m_extFields) {
+      m_extFields[it.first] = it.second;
+    }
+    m_head = command.m_head;
+    m_body = command.m_body;
+    s_seqNumber.store(command.s_seqNumber.load());
+    m_parsedJson = command.m_parsedJson;
+    //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
+}
 
 void RemotingCommand::Encode() {
   Json::Value root;

--- a/src/protocol/RemotingCommand.cpp
+++ b/src/protocol/RemotingCommand.cpp
@@ -50,6 +50,46 @@ RemotingCommand::RemotingCommand(int code, string language, int version,
       m_remark(remark),
       m_pExtHeader(pExtHeader) {}
 
+RemotingCommand::RemotingCommand(const RemotingCommand& command) {
+  m_code = command.m_code;
+  m_language = command.m_language;
+  m_version = command.m_version;
+  m_opaque = command.m_opaque;
+  m_flag = command.m_flag;
+  m_remark = command.m_remark;
+  m_msgBody = command.m_msgBody;
+  
+  for (auto& it : command.m_extFields) {
+	  m_extFields[it.first] = it.second;
+  }
+  m_head = command.m_head;
+  m_body = command.m_body;
+  s_seqNumber.store(command.s_seqNumber.load());
+  m_parsedJson = command.m_parsedJson;
+  //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
+}
+
+
+RemotingCommand& RemotingCommand::operator=(const RemotingCommand& command) {
+  m_code = command.m_code;
+  m_language = command.m_language;
+  m_version = command.m_version;
+  m_opaque = command.m_opaque;
+  m_flag = command.m_flag;
+  m_remark = command.m_remark;
+  m_msgBody = command.m_msgBody;
+  
+  for (auto& it : command.m_extFields) {
+	  m_extFields[it.first] = it.second;
+  }
+  m_head = command.m_head;
+  m_body = command.m_body;
+  s_seqNumber.store(command.s_seqNumber.load());
+  m_parsedJson = command.m_parsedJson;
+  //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
+  return *this;
+}
+
 RemotingCommand::~RemotingCommand() { m_pExtHeader = NULL; }
 
 void RemotingCommand::Encode() {
@@ -248,6 +288,17 @@ string RemotingCommand::getMsgBody() const { return m_msgBody; }
 
 void RemotingCommand::addExtField(const string& key, const string& value) {
   m_extFields[key] = value;
+}
+
+std::string RemotingCommand::ToString() {
+	 std::stringstream ss;
+	 ss << "code:" << m_code
+	  <<",opaque:"<< m_opaque
+	  <<",flag:"<< m_flag
+	  <<",seqNumber:" << s_seqNumber
+	  <<",body.size:" << m_body.getSize()
+	  <<",header.size:" << m_head.getSize();
+	 return ss.str();
 }
 
 }  //<!end namespace;

--- a/src/protocol/RemotingCommand.h
+++ b/src/protocol/RemotingCommand.h
@@ -37,16 +37,12 @@ class RemotingCommand {
                   string remark, CommandHeader* pCustomHeader);
   RemotingCommand(const RemotingCommand& command);
   RemotingCommand& operator=(const RemotingCommand& command);
-
   virtual ~RemotingCommand();
-
   const MemoryBlock* GetHead() const;
   const MemoryBlock* GetBody() const;
-
   void SetBody(const char* pData, int len);
   void setOpaque(const int opa);
   void SetExtHeader(int code);
-
   void setCode(int code);
   int getCode() const;
   int getOpaque() const;
@@ -57,21 +53,18 @@ class RemotingCommand {
   void markOnewayRPC();
   bool isOnewayRPC();
   void setParsedJson(Json::Value json);
-
   CommandHeader* getCommandHeader() const;
   const int getFlag() const;
   const int getVersion() const;
-
   void addExtField(const string& key, const string& value);
   string getMsgBody() const;
   void setMsgBody(const string& body);
-
  public:
   void Encode();
   static RemotingCommand* Decode(const MemoryBlock& mem);
-
-  std::string ToString();
-
+  std::string ToString() const;
+ private:
+ void Assign(const RemotingCommand& command);
  private:
   int m_code;
   string m_language;

--- a/src/protocol/RemotingCommand.h
+++ b/src/protocol/RemotingCommand.h
@@ -31,9 +31,13 @@ const int RPC_ONEWAY = 1;  // 0, RPC // 1, Oneway;
 //<!***************************************************************************
 class RemotingCommand {
  public:
+  RemotingCommand() : m_code(0) {};
   RemotingCommand(int code, CommandHeader* pCustomHeader = NULL);
   RemotingCommand(int code, string language, int version, int opaque, int flag,
                   string remark, CommandHeader* pCustomHeader);
+  RemotingCommand(const RemotingCommand& command);
+  RemotingCommand& operator=(const RemotingCommand& command);
+
   virtual ~RemotingCommand();
 
   const MemoryBlock* GetHead() const;
@@ -65,6 +69,8 @@ class RemotingCommand {
  public:
   void Encode();
   static RemotingCommand* Decode(const MemoryBlock& mem);
+
+  std::string ToString();
 
  private:
   int m_code;

--- a/src/transport/ResponseFuture.cpp
+++ b/src/transport/ResponseFuture.cpp
@@ -31,6 +31,9 @@ ResponseFuture::ResponseFuture(int requestCode, int opaque,
   m_pCallbackWrap = pcall;
   m_pResponseCommand = NULL;
   m_sendRequestOK = false;
+  m_maxRetrySendTimes = 1;
+  m_retrySendTimes = 1;
+  m_brokerAddr = "";
   m_beginTimestamp = UtilAll::currentTimeMillis();
   m_asyncCallbackStatus = asyncCallBackStatus_init;
   if (getASyncFlag()) {
@@ -148,6 +151,10 @@ void ResponseFuture::executeInvokeCallbackException() {
     return;
   } else {
     if (m_asyncCallbackStatus == asyncCallBackStatus_timeout) {
+
+	//here no need retrySendTimes process because of it have timeout
+	LOG_ERROR("send msg, callback timeout, opaque:%d, sendTimes:%d, maxRetryTimes:%d", getOpaque(), getRetrySendTimes(), getMaxRetrySendTimes());
+
       m_pCallbackWrap->onException();
     } else {
       LOG_WARN(
@@ -162,6 +169,39 @@ bool ResponseFuture::isTimeOut() const {
   int64 diff = UtilAll::currentTimeMillis() - m_beginTimestamp;
   //<!only async;
   return m_bAsync.load() == 1 && diff > m_timeout;
+}
+
+int ResponseFuture::getMaxRetrySendTimes() const {
+	return m_maxRetrySendTimes;
+} 
+int ResponseFuture::getRetrySendTimes() const {
+	return m_retrySendTimes;
+}
+
+void ResponseFuture::setMaxRetrySendTimes(int maxRetryTimes) {
+	m_maxRetrySendTimes = maxRetryTimes;
+}
+void ResponseFuture::setRetrySendTimes(int retryTimes) {
+	m_retrySendTimes = retryTimes;
+}
+
+void ResponseFuture::setBrokerAddr(const std::string& brokerAddr) {
+	m_brokerAddr = brokerAddr;
+}
+void ResponseFuture::setRequestCommand(const RemotingCommand& requestCommand) {
+	m_requestCommand = requestCommand;
+}
+
+const RemotingCommand& ResponseFuture::getRequestCommand() {
+	return m_requestCommand;
+}
+std::string ResponseFuture::getBrokerAddr() const {
+	return m_brokerAddr;
+}
+
+int64 ResponseFuture::leftTime() const {
+	int64 diff = UtilAll::currentTimeMillis() - m_beginTimestamp;
+	return m_timeout - diff;
 }
 
 RemotingCommand* ResponseFuture::getCommand() const {

--- a/src/transport/ResponseFuture.h
+++ b/src/transport/ResponseFuture.h
@@ -51,7 +51,10 @@ class ResponseFuture {
   //<!callback;
   void executeInvokeCallback();
   void executeInvokeCallbackException();
-  bool isTimeOut() const;
+  bool isTimeOut() const; 
+  int getMaxRetrySendTimes() const; 
+  int getRetrySendTimes() const;   
+  int64 leftTime() const;
   // bool    isTimeOutMoreThan30s() const;
   const bool getASyncFlag();
   void setAsyncResponseFlag();
@@ -59,7 +62,12 @@ class ResponseFuture {
   const bool getSyncResponseFlag();
   AsyncCallbackWrap* getAsyncCallbackWrap();
   void setAsyncCallBackStatus(asyncCallBackStatus asyncCallbackStatus);
-
+  void setMaxRetrySendTimes(int maxRetryTimes); 
+  void setRetrySendTimes(int retryTimes);   
+  void setBrokerAddr(const std::string& brokerAddr); 
+  void setRequestCommand(const RemotingCommand& requestCommand);
+  const RemotingCommand& getRequestCommand();
+  std::string getBrokerAddr() const;
  private:
   int m_requestCode;
   int m_opaque;
@@ -75,6 +83,11 @@ class ResponseFuture {
   asyncCallBackStatus m_asyncCallbackStatus;
   boost::atomic<bool> m_asyncResponse;
   boost::atomic<bool> m_syncResponse;
+
+  int   m_maxRetrySendTimes;
+  int   m_retrySendTimes; 
+  std::string m_brokerAddr;
+  RemotingCommand m_requestCommand;
   // TcpRemotingClient*    m_tcpRemoteClient;
 };
 //<!************************************************************************

--- a/src/transport/TcpRemotingClient.cpp
+++ b/src/transport/TcpRemotingClient.cpp
@@ -718,7 +718,7 @@ void TcpRemotingClient::eraseTimerCallback(int opaque) {
 void TcpRemotingClient::cancelTimerCallback(int opaque) {
   boost::lock_guard<boost::mutex> lock(m_timerMapMutex);
   if (m_async_timer_map.find(opaque) != m_async_timer_map.end()) {
-  	LOG_DEBUG("cancelTimerCallback: opaque:%lld", opaque);    
+    LOG_DEBUG("cancelTimerCallback: opaque:%lld", opaque);    
     boost::asio::deadline_timer* t = m_async_timer_map[opaque];
     t->cancel();
     delete t;

--- a/src/transport/TcpRemotingClient.h
+++ b/src/transport/TcpRemotingClient.h
@@ -46,11 +46,10 @@ class TcpRemotingClient {
 
   bool invokeHeartBeat(const string& addr, RemotingCommand& request);
 
-  bool invokeAsync(const string& addr, RemotingCommand& request,
-                   AsyncCallbackWrap* cbw, int64 timeoutMilliseconds);
-
+  bool invokeAsync(const string& addr, RemotingCommand& request, AsyncCallbackWrap* cbw, 
+                   int64 timeoutMilliseconds, int maxRetrySendTimes=1, int retrySendTimes=1);
   void invokeOneway(const string& addr, RemotingCommand& request);
-
+  
   void ProcessData(const MemoryBlock& mem, const string& addr);
 
   void registerProcessor(MQRequestCode requestCode,


### PR DESCRIPTION
#44 autoRetryTimes doesn't work for producer async send #44

log of test and verify:

2019-Jan-03 14:08:30.493682:sendMessageAsync request:code:10,opaque:998,flag:0,seqNumber:999,body.size:22,header.size:442, timeout:3000, maxRetryTimes:3 retrySendTimes:1
2019-Jan-03 14:08:30.493725:invokeAsync success, addr:101.132.96.164:10911, code:10, opaque:998
2019-Jan-03 14:08:30.697239:code:2, remark:JAVA, version:273, opaque:998, flag:1, remark:[TIMEOUT_CLEAN_QUEUE]broker busy, start flow control for a while, period in queue: 201ms, size of queue: 223, headLen:217, bodyLen:0
2019-Jan-03 14:08:30.697285:processResponseCommand, code:10,opaque:998, maxRetryTimes:3, retrySendTimes:1
2019-Jan-03 14:08:30.697343:cancelTimerCallback: opaque:998
2019-Jan-03 14:08:30.697407:handleAsyncPullForResponseTimeout opaque:998, e_code:0, msg:Success
2019-Jan-03 14:08:30.697500:retry send, opaque:998, sendTimes:2, maxRetryTimes:3, left_timeout:2796, brokerAddr:101.132.96.164:10911, msg:Message [topic=jonnxu_topic, flag=0, tag=*]
2019-Jan-03 14:08:30.697724:sendMessageAsync request:code:10,opaque:998,flag:0,seqNumber:1004,body.size:22,header.size:442, timeout:2796, maxRetryTimes:3 retrySendTimes:2
2019-Jan-03 14:08:30.698857:invokeAsync success, addr:101.132.96.164:10911, code:10, opaque:998
2019-Jan-03 14:08:30.869752:code:11, remark:JAVA, version:273, opaque:998, flag:1, remark:, headLen:239, bodyLen:0
2019-Jan-03 14:08:30.869801:processResponseCommand, code:10,opaque:998, maxRetryTimes:3, retrySendTimes:2
2019-Jan-03 14:08:30.869824:cancelTimerCallback: opaque:998
2019-Jan-03 14:08:30.869854:handleAsyncPullForResponseTimeout opaque:998, e_code:0, msg:Success
2019-Jan-03 14:08:30.869854:operationComplete: processSendResponse success, opaque:998, maxRetryTime:3, retrySendTimes:2