### PR TITLE
[ISSUE #52]Fix infinite loop on tcptransport connect

### DIFF
--- a/src/transport/TcpTransport.cpp
+++ b/src/transport/TcpTransport.cpp
@@ -35,7 +35,7 @@ TcpTransport::TcpTransport(TcpRemotingClient *pTcpRemointClient,
       m_event_base_cv(),
       m_ReadDatathread(NULL),
       m_readcallback(handle),
-      m_tcpRemotingClient(pTcpRemointClient){
+      m_tcpRemotingClient(pTcpRemointClient) {
   m_startTime = UtilAll::currentTimeMillis();
 #ifdef WIN32
   evthread_use_windows_threads();
@@ -87,12 +87,14 @@ tcpConnectStatus TcpTransport::connect(const string &strServerURL,
     LOG_INFO("try to connect to fd:%d, addr:%s", fd, (hostName.c_str()));
 
     evthread_make_base_notifiable(m_eventBase);
-    
-    m_ReadDatathread = new boost::thread(boost::bind(&TcpTransport::runThread, this));
-    
-    while(!m_event_base_status) {
+
+    m_ReadDatathread =
+        new boost::thread(boost::bind(&TcpTransport::runThread, this));
+
+    while (!m_event_base_status) {
       LOG_INFO("Wait till event base is looping");
-      boost::system_time const timeout=boost::get_system_time()+ boost::posix_time::milliseconds(1000);
+      boost::system_time const timeout =
+          boost::get_system_time() + boost::posix_time::milliseconds(1000);
       boost::unique_lock<boost::mutex> lock(m_event_base_mtx);
       m_event_base_cv.timed_wait(lock, timeout);
     }
@@ -182,7 +184,6 @@ void TcpTransport::exitBaseDispatch() {
 void TcpTransport::runThread() {
   while (m_ReadDatathread) {
     if (m_eventBase != NULL) {
-      
       if (!m_event_base_status) {
         boost::mutex::scoped_lock lock(m_event_base_mtx);
         m_event_base_status.store(true);
@@ -349,4 +350,4 @@ const string TcpTransport::getPeerAddrAndPort() {
 
 const uint64_t TcpTransport::getStartTime() const { return m_startTime; }
 
-}  //<!end namespace;
+}  // namespace rocketmq

--- a/src/transport/TcpTransport.cpp
+++ b/src/transport/TcpTransport.cpp
@@ -182,22 +182,20 @@ void TcpTransport::exitBaseDispatch() {
 }
 
 void TcpTransport::runThread() {
-  while (m_ReadDatathread) {
-    if (m_eventBase != NULL) {
-      if (!m_event_base_status) {
-        boost::mutex::scoped_lock lock(m_event_base_mtx);
-        m_event_base_status.store(true);
-        m_event_base_cv.notify_all();
-        LOG_INFO("Notify on event_base_dispatch");
-      }
-      event_base_dispatch(m_eventBase);
-      // event_base_loop(m_eventBase, EVLOOP_ONCE);//EVLOOP_NONBLOCK should not
-      // be used, as could not callback event immediatly
+  if (m_eventBase != NULL) {
+    if (!m_event_base_status) {
+      boost::mutex::scoped_lock lock(m_event_base_mtx);
+      m_event_base_status.store(true);
+      m_event_base_cv.notify_all();
+      LOG_INFO("Notify on event_base_dispatch");
     }
-    LOG_INFO("event_base_dispatch exit once");
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1));
-    if (getTcpConnectStatus() != e_connectSuccess) return;
+    event_base_dispatch(m_eventBase);
+    // event_base_loop(m_eventBase, EVLOOP_ONCE);//EVLOOP_NONBLOCK should not
+    // be used, as could not callback event immediatly
   }
+  LOG_INFO("event_base_dispatch exit once");
+  boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+  if (getTcpConnectStatus() != e_connectSuccess) return;
 }
 
 void TcpTransport::timeoutcb(evutil_socket_t fd, short what, void *arg) {


### PR DESCRIPTION
The execution order of these two steps below are uncertain:
1. Assignment of 'm_ReadDatathread';
2. The thread runs 'TcpTransport::runThread';

If the thread runs first, the value of m_ReadDatathread will be NULL, the codes inside 'while (m_ReadDatathread) {}' will never be executed, then 'm_event_base_status' will never store 'true', so TcpTransport::connect will stay on the loop infintely.