### PR TITLE
[ISSUE#43] One Consumer Consume One Message Twice at the same time

### DIFF
--- a/src/MQClientAPIImpl.h
+++ b/src/MQClientAPIImpl.h
@@ -167,6 +167,8 @@ class MQClientAPIImpl {
                         SendCallback* pSendCallback, int64 timeoutMilliseconds,
                         int maxRetryTimes=1,
                         int retrySendTimes=1);
+  void deleteOpaqueForDropPullRequest(const MQMessageQueue& mq, int opaque);
+
  private:
   SendResult sendMessageSync(const string& addr, const string& brokerName,
                              const MQMessage& msg, RemotingCommand& request,

--- a/src/MQClientFactory.cpp
+++ b/src/MQClientFactory.cpp
@@ -1040,6 +1040,17 @@ void MQClientFactory::findConsumerIds(
   }
 }
 
+void MQClientFactory::removeDropedPullRequestOpaque(PullRequest* pullRequest) {
+  //delete the opaque record that's ignore the response of this pullrequest when drop pullrequest
+  if (!pullRequest) return;
+  MQMessageQueue mq = pullRequest->m_messageQueue;
+  int opaque = pullRequest->getLatestPullRequestOpaque();
+  if (opaque > 0) {
+      LOG_INFO("####### need delete the pullrequest for opaque:%d, mq:%s", opaque, mq.toString().data());
+      getMQClientAPIImpl()->deleteOpaqueForDropPullRequest(mq, opaque);
+  }
+}
+
 void MQClientFactory::resetOffset(
     const string& group, const string& topic,
     const map<MQMessageQueue, int64>& offsetTable) {
@@ -1052,6 +1063,9 @@ void MQClientFactory::resetOffset(
       PullRequest* pullreq = pConsumer->getRebalance()->getPullRequest(mq);
       if (pullreq) {
         pullreq->setDroped(true);
+        LOG_INFO("resetOffset setDroped for opaque:%d, mq:%s", pullreq->getLatestPullRequestOpaque(), mq.toString().data());
+        //delete the opaque record that's ignore the response of this pullrequest when drop pullrequest
+        removeDropedPullRequestOpaque(pullreq);
         pullreq->clearAllMsgs();
         pullreq->updateQueueMaxOffset(it->second);
       } else {

--- a/src/MQClientFactory.h
+++ b/src/MQClientFactory.h
@@ -113,7 +113,7 @@ class MQClientFactory {
                           map<int, string>& brokerAddrs);
   map<string, map<int, string>> getBrokerAddrMap();
   void clearBrokerAddrMap();
-
+  void removeDropedPullRequestOpaque(PullRequest* pullRequest);
  private:
   void unregisterClient(const string& producerGroup,
                         const string& consumerGroup,

--- a/src/common/AsyncArg.h
+++ b/src/common/AsyncArg.h
@@ -21,7 +21,7 @@
 #include "MQMessageQueue.h"
 #include "PullAPIWrapper.h"
 #include "SubscriptionData.h"
-
+#include "../consumer/PullRequest.h"
 namespace rocketmq {
 //<!***************************************************************************
 
@@ -29,6 +29,7 @@ struct AsyncArg {
   MQMessageQueue mq;
   SubscriptionData subData;
   PullAPIWrapper* pPullWrapper;
+  PullRequest* pPullRequest;
 };
 
 //<!***************************************************************************

--- a/src/consumer/DefaultMQPullConsumer.cpp
+++ b/src/consumer/DefaultMQPullConsumer.cpp
@@ -263,6 +263,7 @@ void DefaultMQPullConsumer::pullAsyncImpl(const MQMessageQueue& mq,
   arg.mq = mq;
   arg.subData = *pSData;
   arg.pPullWrapper = m_pPullAPIWrapper;
+  arg.pPullRequest = NULL;
 
   try {
     unique_ptr<PullResult> pullResult(m_pPullAPIWrapper->pullKernelImpl(

--- a/src/consumer/DefaultMQPushConsumer.cpp
+++ b/src/consumer/DefaultMQPushConsumer.cpp
@@ -840,7 +840,7 @@ namespace rocketmq {
         arg.mq = messageQueue;
         arg.subData = *pSdata;
         arg.pPullWrapper = m_pPullAPIWrapper;
-
+        arg.pPullRequest = request;
         try {
             request->setLastPullTimestamp(UtilAll::currentTimeMillis());
             m_pPullAPIWrapper->pullKernelImpl(

--- a/src/consumer/PullRequest.cpp
+++ b/src/consumer/PullRequest.cpp
@@ -28,7 +28,8 @@ PullRequest::PullRequest(const string& groupname)
       m_queueOffsetMax(0),
       m_bDroped(false),
       m_bLocked(false),
-      m_bPullMsgEventInprogress(false) {}
+      m_bPullMsgEventInprogress(false),
+      m_latestPullRequestOpaque(0) {}
 
 PullRequest::~PullRequest() {
   m_msgTreeMapTemp.clear();
@@ -45,6 +46,7 @@ PullRequest& PullRequest::operator=(const PullRequest& other) {
     m_messageQueue = other.m_messageQueue;
     m_msgTreeMap = other.m_msgTreeMap;
     m_msgTreeMapTemp = other.m_msgTreeMapTemp;
+    m_latestPullRequestOpaque = other.m_latestPullRequestOpaque;
   }
   return *this;
 }
@@ -258,6 +260,14 @@ bool PullRequest::addPullMsgEvent() {
     return true;
   }
   return false;
+}
+
+int PullRequest::getLatestPullRequestOpaque() const {
+    return m_latestPullRequestOpaque;
+}
+
+void PullRequest::setLatestPullRequestOpaque(int opaque) {
+    m_latestPullRequestOpaque = opaque;
 }
 
 //<!***************************************************************************

--- a/src/consumer/PullRequest.cpp
+++ b/src/consumer/PullRequest.cpp
@@ -263,10 +263,12 @@ bool PullRequest::addPullMsgEvent() {
 }
 
 int PullRequest::getLatestPullRequestOpaque() const {
+    boost::lock_guard<boost::mutex> lock(m_pullRequestLock);
     return m_latestPullRequestOpaque;
 }
 
 void PullRequest::setLatestPullRequestOpaque(int opaque) {
+    boost::lock_guard<boost::mutex> lock(m_pullRequestLock);
     m_latestPullRequestOpaque = opaque;
 }
 

--- a/src/consumer/PullRequest.h
+++ b/src/consumer/PullRequest.h
@@ -69,6 +69,8 @@ class PullRequest {
   boost::timed_mutex& getPullRequestCriticalSection();
   void removePullMsgEvent();
   bool addPullMsgEvent();
+  int getLatestPullRequestOpaque() const;
+  void setLatestPullRequestOpaque(int opaque);
 
  public:
   MQMessageQueue m_messageQueue;
@@ -88,6 +90,7 @@ class PullRequest {
   //uint64 m_tryUnlockTimes;
   uint64 m_lastPullTimestamp;
   uint64 m_lastConsumeTimestamp;
+  int    m_latestPullRequestOpaque;
   boost::timed_mutex m_consumeLock;
   boost::atomic<bool> m_bPullMsgEventInprogress;
 };

--- a/src/consumer/Rebalance.cpp
+++ b/src/consumer/Rebalance.cpp
@@ -471,11 +471,13 @@ bool RebalancePush::updateRequestTableInRebalance(
           (find(mqsSelf.begin(), mqsSelf.end(), mqtemp) == mqsSelf.end())) {
         if (!(it->second->isDroped())) {
           it->second->setDroped(true);
+          //delete the lastest pull request for this mq, which hasn't been response
+          m_pClientFactory->removeDropedPullRequestOpaque(it->second);
           removeUnnecessaryMessageQueue(mqtemp);
           it->second->clearAllMsgs();  // add clear operation to avoid bad state
                                        // when dropped pullRequest returns
                                        // normal
-          LOG_INFO("drop mq:%s", mqtemp.toString().c_str());
+          LOG_INFO("drop mq:%s, delete opaque:%d", mqtemp.toString().c_str(), it->second->getLatestPullRequestOpaque());
         }
         changed = true;
       }

--- a/src/transport/TcpRemotingClient.h
+++ b/src/transport/TcpRemotingClient.h
@@ -58,6 +58,7 @@ class TcpRemotingClient {
   void boost_asio_work();
   void handleAsyncPullForResponseTimeout(const boost::system::error_code& e,
                                          int opaque);
+  void deleteOpaqueForDropPullRequest(const MQMessageQueue& mq, int opaque);
 
  private:
   static void static_messageReceived(void* context, const MemoryBlock& mem,


### PR DESCRIPTION
#43  One Consumer Consume One Message Twice At The Same Time

 test and verify log:
[2019-Jan-08 23:52:32.136558](debug):pullMessageAsync set opaque:31, mq:MessageQueue [topic=jonnxu_topic, brokerName=broker-a, queueId=2]
[2019-Jan-08 23:52:32.136723](debug):invokeAsync success, addr:101.132.96.164:10911, code:11, opaque:31

[2019-Jan-08 23:52:49.905802](info):####### need delete the pullrequest for opaque:31, mq:MessageQueue [topic=jonnxu_topic, brokerName=broker-a, queueId=2]
[2019-Jan-08 23:52:49.905819](debug):succ deleted the async pullrequest for opaque:31, mq:MessageQueue [topic=jonnxu_topic, brokerName=broker-a, queueId=2]
[2019-Jan-08 23:52:49.905833](debug):cancelTimerCallback: opaque:31
[2019-Jan-08 23:52:49.905878](debug):handleAsyncPullForResponseTimeout opaque:31, e_code:0, msg:Success
[2019-Jan-08 23:52:49.906101](info):drop mq:MessageQueue [topic=jonnxu_topic, brokerName=broker-a, queueId=2], delete opaque:31
[2019-Jan-08 23:52:51.368690](debug):code:19, remark:JAVA, version:273, opaque:31, flag:1, remark:OFFSET_OVERFLOW_ONE, headLen:233, bodyLen:0
[2019-Jan-08 23:52:51.368702](debug):broker addr: 101.132.96.164, broker port: 10911
[2019-Jan-08 23:52:51.368757](debug):responseFuture was deleted by timeout of opaque:31