### PR TITLE
remove copying the dir doc and changelog in deploy.sh because of the two dirs not exist

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,8 +30,6 @@ cp -rf ${CWD_DIR}/bin/*.a    ${DEPLOY_BUILD_HOME}/lib/
 cp -rf ${CWD_DIR}/bin/*.so   ${DEPLOY_BUILD_HOME}/lib/
 cp -rf ${CWD_DIR}/include    ${DEPLOY_BUILD_HOME}/
 cp -rf ${CWD_DIR}/example    ${DEPLOY_BUILD_HOME}/
-cp -rf ${CWD_DIR}/doc 	     ${DEPLOY_BUILD_HOME}/
-cp -rf ${CWD_DIR}/changelog  ${DEPLOY_BUILD_HOME}/
 cp -rf ${CWD_DIR}/README.md  ${DEPLOY_BUILD_HOME}/
 
 cd ${CWD_DIR} && tar -cvzf ./${VERSION}.tar.gz ./${VERSION}  >/dev/null 2>&1


### PR DESCRIPTION

I run deploy.sh and I get the error :
```bash
cp: cannot stat '/xxx/rocketmq-client-cpp/doc': No such file or directory
cp: cannot stat '/xxx/rocketmq-client-cpp/changelog': No such file or directory
```