### PR TITLE
[ISSUE #84] fixed duplicated opaque

### DIFF
--- a/src/protocol/RemotingCommand.cpp
+++ b/src/protocol/RemotingCommand.cpp
@@ -63,24 +63,23 @@ RemotingCommand& RemotingCommand::operator=(const RemotingCommand& command) {
 
 RemotingCommand::~RemotingCommand() { m_pExtHeader = NULL; }
 
-void RemotingCommand::Assign(const RemotingCommand& command)
-{
-    m_code = command.m_code;
-    m_language = command.m_language;
-    m_version = command.m_version;
-    m_opaque = command.m_opaque;
-    m_flag = command.m_flag;
-    m_remark = command.m_remark;
-    m_msgBody = command.m_msgBody;
-    
-    for (auto& it : command.m_extFields) {
-      m_extFields[it.first] = it.second;
-    }
-    m_head = command.m_head;
-    m_body = command.m_body;
-    s_seqNumber.store(command.s_seqNumber.load());
-    m_parsedJson = command.m_parsedJson;
-    //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
+void RemotingCommand::Assign(const RemotingCommand &command) {
+  m_code = command.m_code;
+  m_language = command.m_language;
+  m_version = command.m_version;
+  m_opaque = command.m_opaque;
+  m_flag = command.m_flag;
+  m_remark = command.m_remark;
+  m_msgBody = command.m_msgBody;
+
+  for (auto &it : command.m_extFields) {
+    m_extFields[it.first] = it.second;
+  }
+
+  m_head = command.m_head;
+  m_body = command.m_body;
+  m_parsedJson = command.m_parsedJson;
+  //m_pExtHeader = command.m_pExtHeader; //ignore this filed at this moment, if need please add it
 }
 
 void RemotingCommand::Encode() {
@@ -282,14 +281,13 @@ void RemotingCommand::addExtField(const string& key, const string& value) {
 }
 
 std::string RemotingCommand::ToString() const {
-	 std::stringstream ss;
-	 ss << "code:" << m_code
-	  <<",opaque:"<< m_opaque
-	  <<",flag:"<< m_flag
-	  <<",seqNumber:" << s_seqNumber
-	  <<",body.size:" << m_body.getSize()
-	  <<",header.size:" << m_head.getSize();
-	 return ss.str();
+  std::stringstream ss;
+  ss << "code:" << m_code
+     << ",opaque:" << m_opaque
+     << ",flag:" << m_flag
+     << ",body.size:" << m_body.getSize()
+     << ",header.size:" << m_head.getSize();
+  return ss.str();
 }
 
 }  //<!end namespace;


### PR DESCRIPTION
## What is the purpose of the change

fixed bug in RemotingCommand::Assign, that cause duplicated opaque allocated by s_seqNumber.

## Brief changelog

delete the operate of copy s_seqNumber in RemotingCommand::Assign.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).