### PR TITLE
[ISSUE #42] Fixed this issue that cann't set namesrv with hostname

### DIFF
--- a/src/transport/TcpTransport.cpp
+++ b/src/transport/TcpTransport.cpp
@@ -65,6 +65,22 @@ tcpConnectStatus TcpTransport::connect(const string &strServerURL,
   memset(&sin, 0, sizeof(sin));
   sin.sin_family = AF_INET;
   sin.sin_addr.s_addr = inet_addr(hostName.c_str());
+ 
+  if (sin.sin_addr.s_addr == INADDR_NONE) {
+	  struct hostent *host = gethostbyname(hostName.c_str());
+	  if (!host) {
+		  string info = "Get IP address error: " + hostName;
+		  THROW_MQEXCEPTION(MQClientException, info, -1);
+	  }
+
+	  for (int i = 0; host->h_addr_list[i]; i++) {
+		  sin.sin_addr.s_addr = inet_addr(inet_ntoa(*(struct in_addr*)host->h_addr_list[i]));
+		  if (sin.sin_addr.s_addr != INADDR_NONE) {
+			  break;
+		  }
+	  }
+  }
+ 
   sin.sin_port = htons(portNumber);
 
   m_eventBase = event_base_new();

--- a/src/transport/TcpTransport.h
+++ b/src/transport/TcpTransport.h
@@ -68,6 +68,7 @@ class TcpTransport {
   void freeBufferEvent();
   void exitBaseDispatch();
   void setTcpConnectEvent(tcpConnectStatus connectStatus);
+  u_long getInetAddr(std::string &hostname);
 
  private:
   uint64_t m_startTime;


### PR DESCRIPTION
## What is the purpose of the change

Fixed this issue that cann't set namesrv with hostname

## Brief changelog

 Modify TcpTransport::connect 
  Calling inet_addr for a domain name returns INADDR_NONE
  If return INADDR_NONE call gethostbyname get IP ADDRESS
 

## Verifying this change

roducer->setNamesrvAddr("mq.***.com:9876");

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
