### PR TITLE
Add GetLatestErrorMessage feature

### DIFF
--- a/include/CErrorMessage.h
+++ b/include/CErrorMessage.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef __C_CLIENT_ERROR_H__
+#define __C_CLIENT_ERROR_H__
+
+#include "CCommon.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	 
+	ROCKETMQCLIENT_API const char *GetLatestErrorMessage();  // Return the last error message
+
+#ifdef __cplusplus
+};
+#endif
+#endif //__C_CLIENT_ERROR_H__

--- a/src/common/MQClientErrorContainer.cpp
+++ b/src/common/MQClientErrorContainer.cpp
@@ -28,7 +28,7 @@ namespace rocketmq {
 		return s_instance;
 	}
 
-	void MQClientErrorContainer::setErr(std::string & str) {
+	void MQClientErrorContainer::setErr(std::string str) {
 		this->m_err = str;
 	}
 

--- a/src/common/MQClientErrorContainer.cpp
+++ b/src/common/MQClientErrorContainer.cpp
@@ -19,6 +19,9 @@
  
 #include "MQClientErrorContainer.h"
 
+
+
+
 namespace rocketmq {
 	MQClientErrorContainer * MQClientErrorContainer::s_instance = nullptr;
 
@@ -29,10 +32,12 @@ namespace rocketmq {
 	}
 
 	void MQClientErrorContainer::setErr(std::string str) {
+		boost::lock_guard<boost::mutex> lock(this->mutex);
 		this->m_err = str;
 	}
 
 	std::string MQClientErrorContainer::getErr() {
+		boost::lock_guard<boost::mutex> lock(this->mutex);
 		return this->m_err;
 	}
 }

--- a/src/common/MQClientErrorContainer.cpp
+++ b/src/common/MQClientErrorContainer.cpp
@@ -1,0 +1,39 @@
+#pragma once
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+ 
+#include "MQClientErrorContainer.h"
+
+namespace rocketmq {
+	MQClientErrorContainer * MQClientErrorContainer::s_instance = nullptr;
+
+	MQClientErrorContainer * MQClientErrorContainer::instance() {
+		if (!s_instance)
+			s_instance = new MQClientErrorContainer();
+		return s_instance;
+	}
+
+	void MQClientErrorContainer::setErr(std::string & str) {
+		this->m_err = str;
+	}
+
+	std::string MQClientErrorContainer::getErr() {
+		return this->m_err;
+	}
+}
+ 

--- a/src/common/MQClientErrorContainer.h
+++ b/src/common/MQClientErrorContainer.h
@@ -27,7 +27,7 @@ namespace rocketmq {
 	public:
 		static MQClientErrorContainer * instance();
 
-		void setErr(std::string & str);
+		void setErr(std::string str);
 
 		std::string getErr();
 

--- a/src/common/MQClientErrorContainer.h
+++ b/src/common/MQClientErrorContainer.h
@@ -20,6 +20,8 @@
 #define MQCLIENTERRORCONTAINER_H_INCLUDE
 #include <string>
 #include <exception>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 namespace rocketmq {
 	class  MQClientErrorContainer {
@@ -34,6 +36,7 @@ namespace rocketmq {
 	private:
 		std::string m_err;
 		static MQClientErrorContainer * s_instance;
+		boost::mutex mutex;
 	};
 }
 

--- a/src/common/MQClientErrorContainer.h
+++ b/src/common/MQClientErrorContainer.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef MQCLIENTERRORCONTAINER_H_INCLUDE
+#define MQCLIENTERRORCONTAINER_H_INCLUDE
+#include <string>
+#include <exception>
+
+namespace rocketmq {
+	class  MQClientErrorContainer {
+
+	public:
+		static MQClientErrorContainer * instance();
+
+		void setErr(std::string & str);
+
+		std::string getErr();
+
+	private:
+		std::string m_err;
+		static MQClientErrorContainer * s_instance;
+	};
+}
+
+#endif

--- a/src/extern/CErrorMessage.cpp
+++ b/src/extern/CErrorMessage.cpp
@@ -1,0 +1,33 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "CErrorMessage.h"
+#include "CCommon.h"
+#include "MQClientErrorContainer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	using namespace rocketmq;
+
+	const char *GetLatestErrorMessage() {
+		return MQClientErrorContainer::instance()->getErr().c_str();
+	}
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -24,6 +24,7 @@
 #include "CMQException.h"
 #include <string.h>
 #include <typeinfo>
+#include "MQClientErrorContainer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,6 +97,7 @@ int StartProducer(CProducer* producer) {
   try {
     ((DefaultMQProducer*)producer)->start();
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_START_FAILED;
   }
   return OK;
@@ -151,6 +153,7 @@ int SendMessageSync(CProducer* producer, CMessage* msg, CSendResult* result) {
     strncpy(result->msgId, sendResult.getMsgId().c_str(), MAX_MESSAGE_ID_LENGTH - 1);
     result->msgId[MAX_MESSAGE_ID_LENGTH - 1] = 0;
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_SEND_SYNC_FAILED;
   }
   return OK;
@@ -178,6 +181,7 @@ int SendMessageAsync(CProducer* producer,
       delete cSendCallback;
       cSendCallback = NULL;
     }
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_SEND_ASYNC_FAILED;
   }
   return OK;
@@ -207,6 +211,7 @@ int SendMessageOnewayOrderly(CProducer* producer, CMessage* msg, QueueSelectorCa
     SelectMessageQueue selectMessageQueue(selector);
     defaultMQProducer->sendOneway(*message, &selectMessageQueue, arg);
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_SEND_ONEWAY_FAILED;
   }
   return OK;
@@ -233,6 +238,7 @@ int SendMessageOrderlyAsync(CProducer* producer,
   } catch (exception& e) {
     printf("%s\n", e.what());
     // std::count<<e.what( )<<std::endl;
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_SEND_ORDERLYASYNC_FAILED;
   }
   return OK;
@@ -259,6 +265,7 @@ int SendMessageOrderly(CProducer* producer,
     strncpy(result->msgId, sendResult.getMsgId().c_str(), MAX_MESSAGE_ID_LENGTH - 1);
     result->msgId[MAX_MESSAGE_ID_LENGTH - 1] = 0;
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PRODUCER_SEND_ORDERLY_FAILED;
   }
   return OK;

--- a/src/extern/CPullConsumer.cpp
+++ b/src/extern/CPullConsumer.cpp
@@ -19,6 +19,7 @@
 #include "CMessageExt.h"
 #include "CPullConsumer.h"
 #include "CCommon.h"
+#include "MQClientErrorContainer.h"
 
 using namespace rocketmq;
 using namespace std;
@@ -48,6 +49,7 @@ int StartPullConsumer(CPullConsumer* consumer) {
   try {
     ((DefaultMQPullConsumer*)consumer)->start();
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PULLCONSUMER_START_FAILED;
   }
   return OK;
@@ -150,6 +152,7 @@ int FetchSubscriptionMessageQueues(CPullConsumer* consumer, const char* topic, C
   } catch (MQException& e) {
     *size = 0;
     *mqs = NULL;
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PULLCONSUMER_FETCH_MQ_FAILED;
   }
   return OK;
@@ -174,6 +177,7 @@ CPullResult Pull(CPullConsumer* consumer,
   try {
     cppPullResult = ((DefaultMQPullConsumer*)consumer)->pull(messageQueue, subExpression, offset, maxNums);
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     cppPullResult.pullStatus = BROKER_TIMEOUT;
   }
 
@@ -228,6 +232,7 @@ int ReleasePullResult(CPullResult pullResult) {
     try {
       delete ((PullResult*)pullResult.pData);
     } catch (exception& e) {
+	  MQClientErrorContainer::instance()->setErr(string(e.what()));
       return NULL_POINTER;
     }
   }

--- a/src/extern/CPushConsumer.cpp
+++ b/src/extern/CPushConsumer.cpp
@@ -20,6 +20,7 @@
 #include "CPushConsumer.h"
 #include "CCommon.h"
 #include <map>
+#include "MQClientErrorContainer.h"
 
 using namespace rocketmq;
 using namespace std;
@@ -107,6 +108,7 @@ int StartPushConsumer(CPushConsumer* consumer) {
   try {
     ((DefaultMQPushConsumer*)consumer)->start();
   } catch (exception& e) {
+	MQClientErrorContainer::instance()->setErr(string(e.what()));
     return PUSHCONSUMER_START_FAILED;
   }
   return OK;


### PR DESCRIPTION
## What is the purpose of the change

Add GetLatestErrorMessage feature

## Brief changelog
1、Add MQClientErrorContainer to save the latest error message
2、Provide C interface for getting the latest  error message
3、Modify C interface CPullConsumer,CPushConsumer,CPushConsumer  when occur error  use MQClientErrorContainer save error message

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
