### PR TITLE
Fix incorrect size_type cast to unsigned int

### DIFF
--- a/src/common/NameSpaceUtil.cpp
+++ b/src/common/NameSpaceUtil.cpp
@@ -28,7 +28,7 @@ bool NameSpaceUtil::isEndPointURL(string nameServerAddr) {
 }
 
 string NameSpaceUtil::formatNameServerURL(string nameServerAddr) {
-  unsigned int index = nameServerAddr.find(ENDPOINT_PREFIX);
+  string::size_type index = nameServerAddr.find(ENDPOINT_PREFIX);
   if (index != string::npos) {
     LOG_DEBUG("Get Name Server from endpoint [%s]",
               nameServerAddr.substr(ENDPOINT_PREFIX_LENGTH, nameServerAddr.length() - ENDPOINT_PREFIX_LENGTH).c_str());


### PR DESCRIPTION
## What is the purpose of the change

Change  `find` result type from `unsigned int` to `string::size_type` in NameSpaceUtil.

## Brief changelog

Change  `find` result type from `unsigned int` to `string::size_type` in NameSpaceUtil.

## Verifying this change

build and test

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [ ] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
