### PR TITLE
optimize BatchMessage detection in DefaultMQProducer::sendKernelImpl

### DIFF
--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-#include "DefaultMQProducer.h"
+#include "CProducer.h"
+
+#include <string.h>
+#include <typeindex>
+
 #include "AsyncCallback.h"
 #include "CBatchMessage.h"
-#include "CProducer.h"
 #include "CCommon.h"
-#include "CSendResult.h"
-#include "CMessage.h"
 #include "CMQException.h"
-#include <string.h>
-#include <typeinfo>
+#include "CMessage.h"
+#include "CSendResult.h"
+#include "DefaultMQProducer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -207,7 +209,7 @@ int SendMessageAsync(CProducer* producer,
     defaultMQProducer->send(*message, cSendCallback);
   } catch (exception& e) {
     if (cSendCallback != NULL) {
-      if (typeid(e) == typeid(MQException)) {
+      if (std::type_index(typeid(e)) == std::type_index(typeid(MQException))) {
         MQException& mqe = (MQException&)e;
         cSendCallback->onException(mqe);
       }

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -16,7 +16,11 @@
  */
 
 #include "DefaultMQProducer.h"
+
 #include <assert.h>
+#include <typeindex>
+
+#include "BatchMessage.h"
 #include "CommandHeader.h"
 #include "CommunicationMode.h"
 #include "Logging.h"
@@ -26,11 +30,9 @@
 #include "MQClientManager.h"
 #include "MQDecoder.h"
 #include "MQProtos.h"
+#include "StringIdMaker.h"
 #include "TopicPublishInfo.h"
 #include "Validators.h"
-#include "StringIdMaker.h"
-#include "BatchMessage.h"
-#include <typeinfo>
 
 namespace rocketmq {
 
@@ -390,8 +392,7 @@ SendResult DefaultMQProducer::sendKernelImpl(MQMessage& msg,
 
   if (!brokerAddr.empty()) {
     try {
-      BatchMessage batchMessage;
-      bool isBatchMsg = (typeid(msg).name() == typeid(batchMessage).name());
+      bool isBatchMsg = std::type_index(typeid(msg)) == std::type_index(typeid(BatchMessage));
       // msgId is produced by client, offsetMsgId produced by broker. (same with java sdk)
       if (!isBatchMsg) {
         string unique_id = StringIdMaker::get_mutable_instance().get_unique_id();
@@ -466,7 +467,7 @@ SendResult DefaultMQProducer::sendAutoRetrySelectImpl(MQMessage& msg,
         lastmq = mq;
       } else {
         LOG_INFO("sendAutoRetrySelectImpl with times:%d", times);
-        vector<MQMessageQueue> mqs(topicPublishInfo->getMessageQueueList());
+        std::vector<MQMessageQueue> mqs(topicPublishInfo->getMessageQueueList());
         for (size_t i = 0; i < mqs.size(); i++) {
           if (mqs[i] == lastmq)
             mq_index = i;
@@ -571,4 +572,4 @@ void DefaultMQProducer::setRetryTimes4Async(int times) {
 }
 
 //<!***************************************************************************
-}  //<!end namespace;
+}  // namespace rocketmq


### PR DESCRIPTION
## What is the purpose of the change

optimize BatchMessage detection in DefaultMQProducer::sendKernelImpl, and fix bug in CProducer.

## Brief changelog

replace:

```
      BatchMessage batchMessage;
      bool isBatchMsg = (typeid(msg).name() == typeid(batchMessage).name());
```

with:

```
      bool isBatchMsg = std::type_index(typeid(msg)) == std::type_index(typeid(BatchMessage));
```


## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
