### PR TITLE
[ISSUE#145] Wrong lock flag for pull request in orderly consume when unlock

### DIFF
--- a/src/consumer/Rebalance.cpp
+++ b/src/consumer/Rebalance.cpp
@@ -311,7 +311,7 @@ void Rebalance::unlock(MQMessageQueue mq) {
       PullRequest* pullreq = getPullRequest(mqs[i]);
       if (pullreq) {
         LOG_INFO("unlock success of mq:%s", mqs[i].toString().c_str());
-        pullreq->setLocked(true);
+        pullreq->setLocked(false);
       } else {
         LOG_ERROR("unlock fails of mq:%s", mqs[i].toString().c_str());
       }

--- a/src/consumer/Rebalance.cpp
+++ b/src/consumer/Rebalance.cpp
@@ -277,7 +277,7 @@ void Rebalance::unlockAll(bool oneway) {
         PullRequest* pullreq = getPullRequest(mqs[i]);
         if (pullreq) {
           LOG_INFO("unlockBatchMQ success of mq:%s", mqs[i].toString().c_str());
-          pullreq->setLocked(true);
+          pullreq->setLocked(false);
         } else {
           LOG_ERROR("unlockBatchMQ fails of mq:%s", mqs[i].toString().c_str());
         }


### PR DESCRIPTION
## What is the purpose of the change
#145  wrong lock flag for pull request in orderly consume when unlock

## Brief changelog
Rebalance.cpp : 314

## Verifying this change
success

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
