### PR TITLE
Fix: skip compressing if message is a batch one

### DIFF
--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -397,11 +397,12 @@ SendResult DefaultMQProducer::sendKernelImpl(MQMessage& msg,
       if (!isBatchMsg) {
         string unique_id = StringIdMaker::get_mutable_instance().get_unique_id();
         msg.setProperty(MQMessage::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX, unique_id);
+
+        // batch does not support compressing right now,
+        tryToCompressMessage(msg);
       }
 
       LOG_DEBUG("produce before:%s to %s", msg.toString().c_str(), mq.toString().c_str());
-
-      tryToCompressMessage(msg);
 
       SendMessageRequestHeader* requestHeader = new SendMessageRequestHeader();
       requestHeader->producerGroup = getGroupName();


### PR DESCRIPTION
## What is the purpose of the change

Currently, BatchMessage might be compressed like a normal Message (when it's size reached the point), and this compressing action will cause an sending error:
```
[2019-Sep-20 14:07:20.254324](error):processSendResponse error remark:java.lang.ArrayIndexOutOfBoundsException, java.util.zip.CRC32.update(CRC32.java:74), error code:1[processSendResponse:537]
[2019-Sep-20 14:07:20.254504](error):send error[sendMessageSync:381]
[2019-Sep-20 14:07:20.254706](error):msg: response is null,error:-1,in file </fakepath/rocketmq-client-cpp/src/MQClientAPIImpl.cpp> line:384[send:147]
```

## Brief changelog

1. Align to JAVA SDK: Skip compressing if message is a batch one. (You can refer to [apache/rocketmq](https://github.com/apache/rocketmq/blob/master/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java#L884) )

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
