### PR TITLE
fix(producer) crash in DestroyProducer shutdown. 

### DIFF
--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -270,7 +270,7 @@ int DestroyProducer(CProducer* pProducer) {
       defaultMQProducer->innerProducer = NULL;
     }
   }
-  delete reinterpret_cast<DefaultMQProducer*>(pProducer);
+  delete reinterpret_cast<DefaultProducer*>(pProducer);
   return OK;
 }
 int StartProducer(CProducer* producer) {


### PR DESCRIPTION
## What is the purpose of the change

[ISSUE #213 ]fix one bug in DestroyProducer which can cause the program core dump  

## Brief changelog

 delete reinterpret_cast<DefaultMQProducer*>(pProducer);
to
 delete reinterpret_cast<DefaultProducer*>(pProducer);

## Verifying this change
run producer in example 
![image](https://user-images.githubusercontent.com/5809934/71805243-ba7ee380-30a0-11ea-9493-8cc3eabe632b.png)


 