### PR TITLE
feat(libevent): update libevent to v2.1.11 to avoid get mutex time out.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ install_lib_dir="${basepath}/bin"
 fname_libevent="libevent*.zip"
 fname_jsoncpp="jsoncpp*.zip"
 fname_boost="boost*.tar.gz"
-fname_libevent_down="release-2.0.22-stable.zip"
+fname_libevent_down="release-2.1.11-stable.zip"
 fname_jsoncpp_down="0.10.6.zip"
 fname_boost_down="1.58.0/boost_1_58_0.tar.gz"
 


### PR DESCRIPTION
## What is the purpose of the change

close #202 , close #204 , close #211 , close #224 , and same close #30 

## Brief changelog

Update Libevent version to 2.1.11-stable

