### PR TITLE
fix(build): fix variable in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -170,7 +170,7 @@ BuildLibevent() {
     exit 1
   fi
 
-  libevent_dir=$(ls | grep libevent | grep .*[^zip]$)
+  libevent_dir=$(ls | grep libevent | grep .*[^zip^txt]$)
   cd ${libevent_dir}
   if [ $? -ne 0 ]; then
     exit 1


### PR DESCRIPTION
## What is the purpose of the change

The line `unzip -o ${fname_libevent} >unziplibevent.txt 2>&` creates the file `unziplibevent.txt` in the directory. So when setting the directory name with `libevent_dir=$(ls | grep libevent | grep .*[^zip]$)` the variable will have the name of two files and ` cd ${libevent_dir}` will prompt `cd: Too many arguments`.
 
## Brief changelog

Just adding the .txt extension to the exclusion list during the grep command is enough to solve the problem. In the end we have `libevent_dir=$(ls | grep libevent | grep .*[^zip^txt]$)`.