### PR TITLE
heap-buffer-overflow risk

### DIFF
--- a/src/protocol/CommandHeader.cpp
+++ b/src/protocol/CommandHeader.cpp
@@ -511,7 +511,7 @@ void ConsumerSendMsgBackRequestHeader::SetDeclaredFieldOfCommandHeader(map<strin
 void GetConsumerListByGroupResponseBody::Decode(const MemoryBlock* mem, vector<string>& cids) {
   cids.clear();
   //<! decode;
-  const char* const pData = static_cast<const char*>(mem->getData());
+  const std::string pData(mem->getData(), mem->getSize());
 
   Json::Reader reader;
   Json::Value root;


### PR DESCRIPTION
## What is the purpose of the change

There is a heap-buffer-overflow risk that when the chars is not with '\0' or chars contain binary data, also may be a short parse. The string constructor should be replace with 'basic_string( const CharT* s, size_type count, const Allocator& alloc = Allocator() )' that specified chars length need be allocate other than expect the constructor 'basic_string( const CharT* s, const Allocator& alloc = Allocator() )' to find '\0' for calculating chars length.

## Brief changelog

Fix a heap-buffer-overflow risk for string constructor.

## Verifying this change

Has verified. Want a code review.

## The ASAN report

==108012==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60f000024f88 at pc 0xd7d1e8 bp 0x7ffdc5e171c0 sp 0x7ffdc5e17198
READ of size 169 at 0x60f000024f88 thread T0 (app_dispatchsrv)
    #0 0xd7d1e7 in __interceptor_strlen (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0xd7d1e7)
    #1 0x1d3e360 in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0x1d3e360)
    #2 0x179a9cc in rocketmq::GetConsumerListByGroupResponseBody::Decode(rocketmq::MemoryBlock const*, std::vector<std::string, std::allocator<std::string> >&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/protocol/CommandHeader.cpp:469
    #3 0x1712eda in rocketmq::MQClientAPIImpl::getConsumerIdListByGroup(std::string const&, std::string const&, std::vector<std::string, std::allocator<std::string> >&, int, rocketmq::SessionCredentials const&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/MQClientAPIImpl.cpp:752
    #4 0x16fc05e in rocketmq::MQClientFactory::findConsumerIds(std::string const&, std::string const&, std::vector<std::string, std::allocator<std::string> >&, rocketmq::SessionCredentials const&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/MQClientFactory.cpp:1027
    #5 0x17a485c in rocketmq::Rebalance::doRebalance() /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/consumer/Rebalance.cpp:90
    #6 0x16d5e84 in rocketmq::DefaultMQPushConsumer::doRebalance() /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/consumer/DefaultMQPushConsumer.cpp:273
    #7 0x16fa677 in rocketmq::MQClientFactory::doRebalance() /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/MQClientFactory.cpp:850
    #8 0x16fa153 in rocketmq::MQClientFactory::rebalanceImmediately() /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/MQClientFactory.cpp:811
    #9 0x16d6613 in rocketmq::DefaultMQPushConsumer::start() /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/consumer/DefaultMQPushConsumer.cpp:382
    #10 0x117945d in RocketMQConsumer::StartConsume() /home/yizhe.wcm/repositories/DispatcherServer/src/layer_utility/mq/rocketmq_consumer.cpp:89
    #11 0x11625e3 in CommonMQConsumer::run() /home/yizhe.wcm/repositories/DispatcherServer/src/layer_utility/mq/common_mqconsumer.cpp:107
    #12 0xe63cbb in CStorageSyncRTLManager::start() /home/yizhe.wcm/repositories/DispatcherServer/src/bservice_storage/storage/StorageSyncRTLManager.cpp:51
    #13 0xe4f4a8 in CStorageSyncManager::run() /home/yizhe.wcm/repositories/DispatcherServer/src/bservice_storage/storage/StorageSyncManager.cpp:49
    #14 0xe4f1be in CStorageSyncManager::CStorageSyncManager(CStorageContext*, CServiceBase*) /home/yizhe.wcm/repositories/DispatcherServer/src/bservice_storage/storage/StorageSyncManager.cpp:29
    #15 0xe6a232 in CStorageSyncResource::GetStorageSyncManager() /home/yizhe.wcm/repositories/DispatcherServer/src/bservice_storage/storage/StorageSyncResource.cpp:36
    #16 0xe214b8 in CServiceDriver_Storage::Startup() /home/yizhe.wcm/repositories/DispatcherServer/src/bservice_storage/ServiceDriver_Storage.cpp:110
    #17 0xfdb03e in CServiceBase::OnStartupDrivers() /home/yizhe.wcm/repositories/DispatcherServer/src/layer_abstract/ServiceBase.cpp:75
    #18 0xfdae4c in CServiceBase::Create(std::string const&, CServiceParameter*) /home/yizhe.wcm/repositories/DispatcherServer/src/layer_abstract/ServiceBase.cpp:57
    #19 0xdcd590 in CAmapDispatcherServer::Start() /home/yizhe.wcm/repositories/DispatcherServer/src/app_dispatcher/AmapDispatcherServer.cpp:179
    #20 0xdd4a14 in Run() /home/yizhe.wcm/repositories/DispatcherServer/src/app_dispatcher/dispatchsrv.cpp:71
    #21 0xdd4ca5 in main /home/yizhe.wcm/repositories/DispatcherServer/src/app_dispatcher/dispatchsrv.cpp:105
    #22 0x7f35949c7444 in __libc_start_main (/lib64/libc.so.6+0x22444)
    #23 0xd65624 (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0xd65624)

0x60f000024f88 is located 0 bytes to the right of 168-byte region [0x60f000024ee0,0x60f000024f88)
allocated by thread T25 here:
    #0 0xda03bf in __interceptor_malloc (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0xda03bf)
    #1 0x16eaf3b in rocketmq::MemoryBlock::setSize(int, bool) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/common/dataBlock.cpp:110
    #2 0x178d044 in rocketmq::RemotingCommand::SetBody(char const*, int) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/protocol/RemotingCommand.cpp:140
    #3 0x178d4cd in rocketmq::RemotingCommand::Decode(rocketmq::MemoryBlock const&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/protocol/RemotingCommand.cpp:181
    #4 0x1772e73 in rocketmq::TcpRemotingClient::ProcessData(rocketmq::MemoryBlock const&, std::string const&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/src/transport/TcpRemotingClient.cpp:479
    #5 0x177f03d in boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>::operator()(rocketmq::TcpRemotingClient*, rocketmq::MemoryBlock const&, std::string const&) const /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/mem_fn_template.hpp:280
    #6 0x177ed3b in void boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> >::operator()<boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list0>(boost::_bi::type<void>, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>&, boost::_bi::list0&, int) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/bind.hpp:392
    #7 0x177ea90 in boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > >::operator()() /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/bind.hpp:893
    #8 0x177e341 in void boost::asio::asio_handler_invoke<boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > > >(boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > >&, ...) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/handler_invoke_hook.hpp:69
    #9 0x177d804 in void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > >, boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > > >(boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > >&, boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > >&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/detail/handler_invoke_helpers.hpp:37
    #10 0x177c137 in boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf2<void, rocketmq::TcpRemotingClient, rocketmq::MemoryBlock const&, std::string const&>, boost::_bi::list3<boost::_bi::value<rocketmq::TcpRemotingClient*>, boost::_bi::value<rocketmq::MemoryBlock>, boost::_bi::value<std::string> > > >::do_complete(boost::asio::detail::task_io_service*, boost::asio::detail::task_io_service_operation*, boost::system::error_code const&, unsigned long) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/detail/completion_handler.hpp:68
    #11 0x142141f in boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/detail/task_io_service_operation.hpp:38
    #12 0x142226f in boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/detail/impl/task_io_service.ipp:372
    #13 0x1421fb6 in boost::asio::detail::task_io_service::run(boost::system::error_code&) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/asio/detail/impl/task_io_service.ipp:149
    #14 0x142256e in boost::asio::io_service::run() ../rpm/.dep_create/include/boost/asio/impl/io_service.ipp:59
    #15 0x14663d6 in boost::_mfi::mf0<unsigned long, boost::asio::io_service>::operator()(boost::asio::io_service*) const /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/mem_fn_template.hpp:49
    #16 0x146633a in unsigned long boost::_bi::list1<boost::_bi::value<boost::asio::io_service*> >::operator()<unsigned long, boost::_mfi::mf0<unsigned long, boost::asio::io_service>, boost::_bi::list0>(boost::_bi::type<unsigned long>, boost::_mfi::mf0<unsigned long, boost::asio::io_service>&, boost::_bi::list0&, long) /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/bind.hpp:243
    #17 0x14662e4 in boost::_bi::bind_t<unsigned long, boost::_mfi::mf0<unsigned long, boost::asio::io_service>, boost::_bi::list1<boost::_bi::value<boost::asio::io_service*> > >::operator()() /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/bind/bind.hpp:893
    #18 0x14662a7 in boost::detail::thread_data<boost::_bi::bind_t<unsigned long, boost::_mfi::mf0<unsigned long, boost::asio::io_service>, boost::_bi::list1<boost::_bi::value<boost::asio::io_service*> > > >::run() /home/yizhe.wcm/repositories/rocketmq-client-cpp/bin/include/boost/thread/detail/thread.hpp:116
    #19 0x171db59 in thread_proxy (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0x171db59)
    #20 0x7f3595293e24 in start_thread (/lib64/libpthread.so.0+0x7e24)
    #21 0x7f3594aa2f1c in __clone (/lib64/libc.so.6+0xfdf1c)

Thread T25 created by T0 (app_dispatchsrv) here:
    #0 0xd6f84a in __interceptor_pthread_create (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0xd6f84a)
    #1 0x171cf59 in boost::thread::start_thread_noexcept() (/home/yizhe.wcm/repositories/DispatcherServer/bin/app_dispatchsrv+0x171cf59)
    #2 0x7ffdc5e1751f ([stack]+0x2351f)

SUMMARY: AddressSanitizer: heap-buffer-overflow ??:0 __interceptor_strlen
Shadow bytes around the buggy address:
  0x0c1e7fffc9a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e7fffc9b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e7fffc9c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1e7fffc9d0: fa fa fa fa fa fa fa fa fa fa fa fa 00 00 00 00
  0x0c1e7fffc9e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c1e7fffc9f0: 00[fa]fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x0c1e7fffca00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1e7fffca10: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c1e7fffca20: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x0c1e7fffca30: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x0c1e7fffca40: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==108012==ABORTING

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
