### PR TITLE
fix(test): fix the heap-buffer-overflow bug and bad/invalid test cases.

### DIFF
--- a/test/src/common/MemoryBlockTest.cpp
+++ b/test/src/common/MemoryBlockTest.cpp
@@ -48,8 +48,8 @@ TEST(memoryBlock, init) {
 
   char* buf = (char*)malloc(sizeof(char) * 9);
   strcpy(buf, "RocketMQ");
-  MemoryBlock fiveMemoryBlock(buf, -1);
-  EXPECT_EQ(fiveMemoryBlock.getSize(), -1);
+  MemoryBlock fiveMemoryBlock(buf, 0);
+  EXPECT_EQ(fiveMemoryBlock.getSize(), 0);
   EXPECT_TRUE(fiveMemoryBlock.getData() == nullptr);
 
   char* bufNull = NULL;
@@ -57,6 +57,7 @@ TEST(memoryBlock, init) {
   EXPECT_EQ(sixMemoryBlock.getSize(), 16);
   EXPECT_TRUE(sixMemoryBlock.getData() != nullptr);
 
+  buf = (char*)realloc(buf, 20);
   MemoryBlock sevenMemoryBlock(buf, 20);
   EXPECT_EQ(sevenMemoryBlock.getSize(), 20);
   sevenMemoryBlock.getData();


### PR DESCRIPTION

## What is the purpose of the change

（1）Fix bad and invalid test cases.
（2）Add a test case for boundary 0.
（3）Fix the heap-buffer-overflow bug.

## Brief changelog

Fix the heap-buffer-overflow bug and bad/invalid test cases.

## Verifying this change


Has been verified and passed the ASAN check.

## The ASAN report
==32183==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000ed70 at pc 0x7f1378d60a1e bp 0x7fff6c9be8c0 sp 0x7fff6c9be8b8
READ of size 20 at 0x60200000ed70 thread T0
    #0 0x7f1378d60a1d in rocketmq::MemoryBlock::MemoryBlock(void const*, unsigned long) (/home/yizhe.wcm/PR/rocketmq-client-cpp/bin/librocketmq.so+0x503a1d)
    #1 0x4dba7a in memoryBlock_init_Test::TestBody() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4dba7a)
    #2 0x50e87b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x50e87b)
    #3 0x508653 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x508653)
    #4 0x4e8e62 in testing::Test::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e8e62)
    #5 0x4e9729 in testing::TestInfo::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e9729)
    #6 0x4e9ded in testing::TestCase::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e9ded)
    #7 0x4f45f0 in testing::internal::UnitTestImpl::RunAllTests() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4f45f0)
    #8 0x50fc79 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x50fc79)
    #9 0x5093d5 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x5093d5)
    #10 0x4f3096 in testing::UnitTest::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4f3096)
    #11 0x4dfd83 in RUN_ALL_TESTS() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4dfd83)
    #12 0x4df621 in main (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4df621)
    #13 0x7f1377c8e444 in __libc_start_main (/lib64/libc.so.6+0x22444)
    #14 0x477a38 (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x477a38)

0x60200000ed79 is located 0 bytes to the right of 9-byte region [0x60200000ed70,0x60200000ed79)
allocated by thread T0 here:
    #0 0x4b27cf in malloc (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4b27cf)
    #1 0x4db544 in memoryBlock_init_Test::TestBody() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4db544)
    #2 0x50e87b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x50e87b)
    #3 0x508653 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x508653)
    #4 0x4e8e62 in testing::Test::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e8e62)
    #5 0x4e9729 in testing::TestInfo::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e9729)
    #6 0x4e9ded in testing::TestCase::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4e9ded)
    #7 0x4f45f0 in testing::internal::UnitTestImpl::RunAllTests() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4f45f0)
    #8 0x50fc79 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x50fc79)
    #9 0x5093d5 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x5093d5)
    #10 0x4f3096 in testing::UnitTest::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4f3096)
    #11 0x4dfd83 in RUN_ALL_TESTS() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4dfd83)
    #12 0x4df621 in main (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/MemoryBlockTest+0x4df621)
    #13 0x7f1377c8e444 in __libc_start_main (/lib64/libc.so.6+0x22444)

SUMMARY: AddressSanitizer: heap-buffer-overflow ??:0 rocketmq::MemoryBlock::MemoryBlock(void const*, unsigned long)
Shadow bytes around the buggy address:
  0x0c047fff9d50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c047fff9da0: fa fa fa fa fa fa fa fa fa fa 00 00 fa fa[00]01
  0x0c047fff9db0: fa fa 00 04 fa fa 00 02 fa fa 00 00 fa fa 00 fa
  0x0c047fff9dc0: fa fa fd fa fa fa 00 fa fa fa 00 fa fa fa 00 fa
  0x0c047fff9dd0: fa fa 00 00 fa fa 00 fa fa fa fd fa fa fa fd fa
  0x0c047fff9de0: fa fa 04 fa fa fa 00 fa fa fa 00 fa fa fa 00 fa
  0x0c047fff9df0: fa fa 00 fa fa fa 00 fa fa fa 00 00 fa fa 00 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==32183==ABORTING

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
