### PR TITLE
feat(version): add api to get SDK versions

### DIFF
--- a/include/CCommon.h
+++ b/include/CCommon.h
@@ -25,6 +25,8 @@ extern "C" {
 #define MAX_MESSAGE_ID_LENGTH 256
 #define MAX_TOPIC_LENGTH 512
 #define MAX_BROKER_NAME_ID_LENGTH 256
+#define MAX_SDK_VERSION_LENGTH 256
+#define DEFAULT_SDK_VERSION "DefaultVersion"
 typedef enum _CStatus_ {
   // Success
   OK = 0,

--- a/include/CProducer.h
+++ b/include/CProducer.h
@@ -47,6 +47,7 @@ ROCKETMQCLIENT_API CProducer* CreateTransactionProducer(const char* groupId,
 ROCKETMQCLIENT_API int DestroyProducer(CProducer* producer);
 ROCKETMQCLIENT_API int StartProducer(CProducer* producer);
 ROCKETMQCLIENT_API int ShutdownProducer(CProducer* producer);
+ROCKETMQCLIENT_API const char* ShowProducerVersion(CProducer* producer);
 
 ROCKETMQCLIENT_API int SetProducerNameServerAddress(CProducer* producer, const char* namesrv);
 ROCKETMQCLIENT_API int SetProducerNameServerDomain(CProducer* producer, const char* domain);

--- a/include/CPullConsumer.h
+++ b/include/CPullConsumer.h
@@ -33,6 +33,8 @@ ROCKETMQCLIENT_API CPullConsumer* CreatePullConsumer(const char* groupId);
 ROCKETMQCLIENT_API int DestroyPullConsumer(CPullConsumer* consumer);
 ROCKETMQCLIENT_API int StartPullConsumer(CPullConsumer* consumer);
 ROCKETMQCLIENT_API int ShutdownPullConsumer(CPullConsumer* consumer);
+ROCKETMQCLIENT_API const char* ShowPullConsumerVersion(CPullConsumer* consumer);
+
 ROCKETMQCLIENT_API int SetPullConsumerGroupID(CPullConsumer* consumer, const char* groupId);
 ROCKETMQCLIENT_API const char* GetPullConsumerGroupID(CPullConsumer* consumer);
 ROCKETMQCLIENT_API int SetPullConsumerNameServerAddress(CPullConsumer* consumer, const char* namesrv);

--- a/include/CPushConsumer.h
+++ b/include/CPushConsumer.h
@@ -36,6 +36,7 @@ ROCKETMQCLIENT_API CPushConsumer* CreatePushConsumer(const char* groupId);
 ROCKETMQCLIENT_API int DestroyPushConsumer(CPushConsumer* consumer);
 ROCKETMQCLIENT_API int StartPushConsumer(CPushConsumer* consumer);
 ROCKETMQCLIENT_API int ShutdownPushConsumer(CPushConsumer* consumer);
+ROCKETMQCLIENT_API const char* ShowPushConsumerVersion(CPushConsumer* consumer);
 ROCKETMQCLIENT_API int SetPushConsumerGroupID(CPushConsumer* consumer, const char* groupId);
 ROCKETMQCLIENT_API const char* GetPushConsumerGroupID(CPushConsumer* consumer);
 ROCKETMQCLIENT_API int SetPushConsumerNameServerAddress(CPushConsumer* consumer, const char* namesrv);

--- a/include/DefaultMQProducer.h
+++ b/include/DefaultMQProducer.h
@@ -35,6 +35,7 @@ class ROCKETMQCLIENT_API DefaultMQProducer {
 
   virtual void start();
   virtual void shutdown();
+  virtual std::string version();
 
   virtual SendResult send(MQMessage& msg, bool bSelectActiveBroker = false);
   virtual SendResult send(MQMessage& msg, const MQMessageQueue& mq);

--- a/include/DefaultMQPullConsumer.h
+++ b/include/DefaultMQPullConsumer.h
@@ -41,6 +41,7 @@ class ROCKETMQCLIENT_API DefaultMQPullConsumer {
 
   virtual void start();
   virtual void shutdown();
+  virtual std::string version();
 
   const std::string& getNamesrvAddr() const;
   void setNamesrvAddr(const std::string& namesrvAddr);

--- a/include/DefaultMQPushConsumer.h
+++ b/include/DefaultMQPushConsumer.h
@@ -36,6 +36,7 @@ class ROCKETMQCLIENT_API DefaultMQPushConsumer {
 
   virtual void start();
   virtual void shutdown();
+  virtual std::string version();
 
   const std::string& getNamesrvAddr() const;
   void setNamesrvAddr(const std::string& namesrvAddr);

--- a/include/TransactionMQProducer.h
+++ b/include/TransactionMQProducer.h
@@ -36,6 +36,7 @@ class ROCKETMQCLIENT_API TransactionMQProducer {
 
   void start();
   void shutdown();
+  std::string version();
 
   const std::string& getNamesrvAddr() const;
   void setNamesrvAddr(const std::string& namesrvAddr);

--- a/src/MQClientFactory.cpp
+++ b/src/MQClientFactory.cpp
@@ -1179,6 +1179,8 @@ ConsumerRunningInfo* MQClientFactory::consumerRunningInfo(const string& consumer
       runningInfo->setProperty(
           ConsumerRunningInfo::PROP_CLIENT_VERSION,
           MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion));  // MQVersion::s_CurrentVersion ));
+      runningInfo->setProperty(ConsumerRunningInfo::PROP_CLIENT_SDK_VERSION,
+                               pConsumer->getClientVersionString());  // in DefaultMQClient.cpp;
 
       return runningInfo;
     }

--- a/src/MQClientFactory.h
+++ b/src/MQClientFactory.h
@@ -143,7 +143,6 @@ class MQClientFactory {
   void doRebalance();
   void timerCB_doRebalance(boost::system::error_code& ec, boost::shared_ptr<boost::asio::deadline_timer> t);
   bool getSessionCredentialFromConsumerTable(SessionCredentials& sessionCredentials);
-  bool addConsumerToTable(const string& consumerName, MQConsumer* pMQConsumer);
   void eraseConsumerFromTable(const string& consumerName);
   int getConsumerTableSize();
   void getTopicListFromConsumerSubscription(set<string>& topicList);
@@ -152,7 +151,6 @@ class MQClientFactory {
 
   // producer related operation
   bool getSessionCredentialFromProducerTable(SessionCredentials& sessionCredentials);
-  bool addProducerToTable(const string& producerName, MQProducer* pMQProducer);
   void eraseProducerFromTable(const string& producerName);
   int getProducerTableSize();
   void insertProducerInfoToHeartBeatData(HeartbeatData* pHeartbeatData);
@@ -170,6 +168,9 @@ class MQClientFactory {
   string m_clientId;
   unique_ptr<MQClientAPIImpl> m_pClientAPIImpl;
   unique_ptr<ClientRemotingProcessor> m_pClientRemotingProcessor;
+
+  bool addProducerToTable(const string& producerName, MQProducer* pMQProducer);
+  bool addConsumerToTable(const string& consumerName, MQConsumer* pMQConsumer);
 
  private:
   string m_nameSrvDomain;  // per clientId

--- a/src/common/DefaultMQClient.cpp
+++ b/src/common/DefaultMQClient.cpp
@@ -28,7 +28,7 @@ namespace rocketmq {
 #define ROCKETMQCPP_VERSION "V2.0.0"
 #define BUILD_DATE "02-14-2020"
 // display version: strings bin/librocketmq.so |grep VERSION
-const char* rocketmq_build_time = "SDK VERSION: " ROCKETMQCPP_VERSION ", BUILD DATE: " BUILD_DATE " ";
+const char* rocketmq_build_time = "SDK VERSION: " ROCKETMQCPP_VERSION ", BUILD DATE: " BUILD_DATE;
 
 //<!************************************************************************
 DefaultMQClient::DefaultMQClient() {

--- a/src/common/DefaultMQClient.cpp
+++ b/src/common/DefaultMQClient.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "include/DefaultMQClient.h"
+#include "DefaultMQClient.h"
 #include "Logging.h"
 #include "MQClientFactory.h"
 #include "MQClientManager.h"
@@ -25,10 +25,10 @@
 
 namespace rocketmq {
 
-#define ROCKETMQCPP_VERSION "2.0.0"
+#define ROCKETMQCPP_VERSION "V2.0.0"
 #define BUILD_DATE "02-14-2020"
 // display version: strings bin/librocketmq.so |grep VERSION
-const char* rocketmq_build_time = "VERSION: " ROCKETMQCPP_VERSION ", BUILD DATE: " BUILD_DATE " ";
+const char* rocketmq_build_time = "SDK VERSION: " ROCKETMQCPP_VERSION ", BUILD DATE: " BUILD_DATE " ";
 
 //<!************************************************************************
 DefaultMQClient::DefaultMQClient() {
@@ -55,6 +55,11 @@ string DefaultMQClient::getMQClientId() const {
   string processId = UtilAll::to_string(getpid());
   // return processId + "-" + clientIP + "@" + m_instanceName;
   return clientIP + "@" + processId + "#" + m_instanceName;
+}
+// version
+string DefaultMQClient::getClientVersionString() const {
+  string version(rocketmq_build_time);
+  return version;
 }
 
 //<!groupName;

--- a/src/common/DefaultMQClient.cpp
+++ b/src/common/DefaultMQClient.cpp
@@ -227,6 +227,19 @@ void DefaultMQClient::setSessionCredentials(const string& input_accessKey,
 const SessionCredentials& DefaultMQClient::getSessionCredentials() const {
   return m_SessionCredentials;
 }
-
+void DefaultMQClient::showClientConfigs() {
+  //LOG_WARN("*****************************************************************************");
+  LOG_WARN("ClientID:%s", getMQClientId().c_str());
+  LOG_WARN("GroupName:%s", m_GroupName.c_str());
+  LOG_WARN("NameServer:%s", m_namesrvAddr.c_str());
+  LOG_WARN("NameServerDomain:%s", m_namesrvDomain.c_str());
+  LOG_WARN("NameSpace:%s", m_nameSpace.c_str());
+  LOG_WARN("InstanceName:%s", m_instanceName.c_str());
+  LOG_WARN("UnitName:%s", m_unitName.c_str());
+  LOG_WARN("PullThreadNum:%d", m_pullThreadNum);
+  LOG_WARN("TcpConnectTimeout:%lld ms", m_tcpConnectTimeout);
+  LOG_WARN("TcpTransportTryLockTimeout:%lld s", m_tcpTransportTryLockTimeout);
+  //LOG_WARN("*****************************************************************************");
+}
 //<!************************************************************************
 }  // namespace rocketmq

--- a/src/common/DefaultMQClient.cpp
+++ b/src/common/DefaultMQClient.cpp
@@ -228,7 +228,7 @@ const SessionCredentials& DefaultMQClient::getSessionCredentials() const {
   return m_SessionCredentials;
 }
 void DefaultMQClient::showClientConfigs() {
-  //LOG_WARN("*****************************************************************************");
+  // LOG_WARN("*****************************************************************************");
   LOG_WARN("ClientID:%s", getMQClientId().c_str());
   LOG_WARN("GroupName:%s", m_GroupName.c_str());
   LOG_WARN("NameServer:%s", m_namesrvAddr.c_str());
@@ -239,7 +239,7 @@ void DefaultMQClient::showClientConfigs() {
   LOG_WARN("PullThreadNum:%d", m_pullThreadNum);
   LOG_WARN("TcpConnectTimeout:%lld ms", m_tcpConnectTimeout);
   LOG_WARN("TcpTransportTryLockTimeout:%lld s", m_tcpTransportTryLockTimeout);
-  //LOG_WARN("*****************************************************************************");
+  // LOG_WARN("*****************************************************************************");
 }
 //<!************************************************************************
 }  // namespace rocketmq

--- a/src/common/DefaultMQClient.cpp
+++ b/src/common/DefaultMQClient.cpp
@@ -24,11 +24,11 @@
 #include "UtilAll.h"
 
 namespace rocketmq {
-
-#define ROCKETMQCPP_VERSION "V2.0.0"
-#define BUILD_DATE "02-14-2020"
+// hard code first.
+#define ROCKETMQCPP_VERSION "2.0.0"
+#define BUILD_DATE "22:50:18 02-14-2020"
 // display version: strings bin/librocketmq.so |grep VERSION
-const char* rocketmq_build_time = "SDK VERSION: " ROCKETMQCPP_VERSION ", BUILD DATE: " BUILD_DATE;
+const char* rocketmq_build_time = "CPP CORE VERSION: " ROCKETMQCPP_VERSION ", BUILD TIME: " BUILD_DATE;
 
 //<!************************************************************************
 DefaultMQClient::DefaultMQClient() {

--- a/src/consumer/DefaultMQPullConsumer.cpp
+++ b/src/consumer/DefaultMQPullConsumer.cpp
@@ -37,10 +37,10 @@ void DefaultMQPullConsumer::shutdown() {
 }
 std::string DefaultMQPullConsumer::version() {
   std::string versions = impl->getClientVersionString();
-  versions.append(", PROTOCOL VERSION: ")
+  /*versions.append(", PROTOCOL VERSION: ")
       .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
       .append(", LANGUAGE: ")
-      .append(MQVersion::s_CurrentLanguage);
+      .append(MQVersion::s_CurrentLanguage);*/
   return versions;
 }
 // start mqclient set

--- a/src/consumer/DefaultMQPullConsumer.cpp
+++ b/src/consumer/DefaultMQPullConsumer.cpp
@@ -36,9 +36,11 @@ void DefaultMQPullConsumer::shutdown() {
   impl->shutdown();
 }
 std::string DefaultMQPullConsumer::version() {
-  std::string versions = impl->getClientVersionString() +
-                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
-                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  std::string versions = impl->getClientVersionString();
+  versions.append(", PROTOCOL VERSION: ")
+      .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
+      .append(", LANGUAGE: ")
+      .append(MQVersion::s_CurrentLanguage);
   return versions;
 }
 // start mqclient set

--- a/src/consumer/DefaultMQPullConsumer.cpp
+++ b/src/consumer/DefaultMQPullConsumer.cpp
@@ -17,6 +17,7 @@
 
 #include "DefaultMQPullConsumer.h"
 #include "DefaultMQPullConsumerImpl.h"
+#include "MQVersion.h"
 
 namespace rocketmq {
 
@@ -34,7 +35,12 @@ void DefaultMQPullConsumer::start() {
 void DefaultMQPullConsumer::shutdown() {
   impl->shutdown();
 }
-
+std::string DefaultMQPullConsumer::version() {
+  std::string versions = impl->getClientVersionString() +
+                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
+                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  return versions;
+}
 // start mqclient set
 const std::string& DefaultMQPullConsumer::getNamesrvAddr() const {
   return impl->getNamesrvAddr();

--- a/src/consumer/DefaultMQPullConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPullConsumerImpl.cpp
@@ -65,6 +65,7 @@ void DefaultMQPullConsumerImpl::start() {
 #endif
   LOG_INFO("###Current Pull Consumer@%s", getClientVersionString().c_str());
   dealWithNameSpace();
+  showClientConfigs();
   switch (m_serviceState) {
     case CREATE_JUST: {
       m_serviceState = START_FAILED;

--- a/src/consumer/DefaultMQPullConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPullConsumerImpl.cpp
@@ -63,6 +63,7 @@ void DefaultMQPullConsumerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
+  LOG_INFO("###Current Pull Consumer@", getClientVersionString().c_str());
   dealWithNameSpace();
   switch (m_serviceState) {
     case CREATE_JUST: {

--- a/src/consumer/DefaultMQPullConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPullConsumerImpl.cpp
@@ -63,7 +63,7 @@ void DefaultMQPullConsumerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
-  LOG_INFO("###Current Pull Consumer@", getClientVersionString().c_str());
+  LOG_INFO("###Current Pull Consumer@%s", getClientVersionString().c_str());
   dealWithNameSpace();
   switch (m_serviceState) {
     case CREATE_JUST: {

--- a/src/consumer/DefaultMQPushConsumer.cpp
+++ b/src/consumer/DefaultMQPushConsumer.cpp
@@ -36,9 +36,11 @@ void DefaultMQPushConsumer::shutdown() {
   impl->shutdown();
 }
 std::string DefaultMQPushConsumer::version() {
-  std::string versions = impl->getClientVersionString() +
-                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
-                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  std::string versions = impl->getClientVersionString();
+  versions.append(", PROTOCOL VERSION: ")
+      .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
+      .append(", LANGUAGE: ")
+      .append(MQVersion::s_CurrentLanguage);
   return versions;
 }
 // ConsumeType DefaultMQPushConsumer::getConsumeType() {

--- a/src/consumer/DefaultMQPushConsumer.cpp
+++ b/src/consumer/DefaultMQPushConsumer.cpp
@@ -37,10 +37,10 @@ void DefaultMQPushConsumer::shutdown() {
 }
 std::string DefaultMQPushConsumer::version() {
   std::string versions = impl->getClientVersionString();
-  versions.append(", PROTOCOL VERSION: ")
+  /*versions.append(", PROTOCOL VERSION: ")
       .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
       .append(", LANGUAGE: ")
-      .append(MQVersion::s_CurrentLanguage);
+      .append(MQVersion::s_CurrentLanguage);*/
   return versions;
 }
 // ConsumeType DefaultMQPushConsumer::getConsumeType() {

--- a/src/consumer/DefaultMQPushConsumer.cpp
+++ b/src/consumer/DefaultMQPushConsumer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "DefaultMQPushConsumer.h"
+#include <MQVersion.h>
 #include "DefaultMQPushConsumerImpl.h"
 
 namespace rocketmq {
@@ -34,7 +35,12 @@ void DefaultMQPushConsumer::start() {
 void DefaultMQPushConsumer::shutdown() {
   impl->shutdown();
 }
-
+std::string DefaultMQPushConsumer::version() {
+  std::string versions = impl->getClientVersionString() +
+                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
+                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  return versions;
+}
 // ConsumeType DefaultMQPushConsumer::getConsumeType() {
 //  return impl->getConsumeType();
 //}

--- a/src/consumer/DefaultMQPushConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPushConsumerImpl.cpp
@@ -193,6 +193,7 @@ class AsyncPullCallback : public PullCallback {
 //<!***************************************************************************
 static boost::mutex m_asyncCallbackLock;
 
+DefaultMQPushConsumerImpl::DefaultMQPushConsumerImpl() {}
 DefaultMQPushConsumerImpl::DefaultMQPushConsumerImpl(const string& groupname)
     : m_consumeFromWhere(CONSUME_FROM_LAST_OFFSET),
       m_pOffsetStore(NULL),

--- a/src/consumer/DefaultMQPushConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPushConsumerImpl.cpp
@@ -308,6 +308,7 @@ void DefaultMQPushConsumerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
+  LOG_INFO("###Current Push Consumer@", getClientVersionString().c_str());
   // deal with name space before start
   dealWithNameSpace();
   switch (m_serviceState) {

--- a/src/consumer/DefaultMQPushConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPushConsumerImpl.cpp
@@ -308,9 +308,10 @@ void DefaultMQPushConsumerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
-  LOG_INFO("###Current Push Consumer@%s", getClientVersionString().c_str());
+  LOG_WARN("###Current Push Consumer@%s", getClientVersionString().c_str());
   // deal with name space before start
   dealWithNameSpace();
+  logConfigs();
   switch (m_serviceState) {
     case CREATE_JUST: {
       m_serviceState = START_FAILED;
@@ -1039,6 +1040,45 @@ bool DefaultMQPushConsumerImpl::dealWithNameSpace() {
   m_subTopics.swap(subTmp);
 
   return true;
+}
+void DefaultMQPushConsumerImpl::logConfigs() {
+  showClientConfigs();
+
+  LOG_WARN("MessageModel:%d", m_messageModel);
+  LOG_WARN("MessageModel:%s", m_messageModel == BROADCASTING ? "BROADCASTING" : "CLUSTERING");
+
+  LOG_WARN("ConsumeFromWhere:%d", m_consumeFromWhere);
+  switch (m_consumeFromWhere) {
+    case CONSUME_FROM_FIRST_OFFSET:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_FIRST_OFFSET");
+      break;
+    case CONSUME_FROM_LAST_OFFSET:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_LAST_OFFSET");
+      break;
+
+    case CONSUME_FROM_TIMESTAMP:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_TIMESTAMP");
+      break;
+    case CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST");
+      break;
+    case CONSUME_FROM_MAX_OFFSET:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_MAX_OFFSET");
+      break;
+    case CONSUME_FROM_MIN_OFFSET:
+      LOG_WARN("ConsumeFromWhere:%s", "CONSUME_FROM_MAX_OFFSET");
+      break;
+    default:
+      LOG_WARN("ConsumeFromWhere:%s", "UnKnown.");
+      break;
+  }
+  LOG_WARN("ConsumeThreadCount:%d", m_consumeThreadCount);
+  LOG_WARN("ConsumeMessageBatchMaxSize:%d", m_consumeMessageBatchMaxSize);
+  LOG_WARN("MaxMsgCacheSizePerQueue:%d", m_maxMsgCacheSize);
+  LOG_WARN("MaxReconsumeTimes:%d", m_maxReconsumeTimes);
+  LOG_WARN("PullMsgThreadPoolNum:%d", m_pullMsgThreadPoolNum);
+  LOG_WARN("AsyncPullMode:%s", m_asyncPull ? "true" : "false");
+  LOG_WARN("AsyncPullTimeout:%d ms", m_asyncPullTimeout);
 }
 //<!************************************************************************
 }  // namespace rocketmq

--- a/src/consumer/DefaultMQPushConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPushConsumerImpl.cpp
@@ -308,7 +308,7 @@ void DefaultMQPushConsumerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
-  LOG_INFO("###Current Push Consumer@", getClientVersionString().c_str());
+  LOG_INFO("###Current Push Consumer@%s", getClientVersionString().c_str());
   // deal with name space before start
   dealWithNameSpace();
   switch (m_serviceState) {

--- a/src/consumer/DefaultMQPushConsumerImpl.h
+++ b/src/consumer/DefaultMQPushConsumerImpl.h
@@ -134,6 +134,7 @@ class DefaultMQPushConsumerImpl : public MQConsumer {
   void copySubscription();
   void updateTopicSubscribeInfoWhenSubscriptionChanged();
   bool dealWithNameSpace();
+  void logConfigs();
 
  private:
   uint64_t m_startTime;

--- a/src/consumer/DefaultMQPushConsumerImpl.h
+++ b/src/consumer/DefaultMQPushConsumerImpl.h
@@ -45,6 +45,7 @@ class ConsumerRunningInfo;
 //<!***************************************************************************
 class DefaultMQPushConsumerImpl : public MQConsumer {
  public:
+  DefaultMQPushConsumerImpl();
   DefaultMQPushConsumerImpl(const std::string& groupname);
   void boost_asio_work();
   virtual ~DefaultMQPushConsumerImpl();

--- a/src/extern/CPullConsumer.cpp
+++ b/src/extern/CPullConsumer.cpp
@@ -27,12 +27,14 @@ using namespace std;
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+char VERSION_FOR_PULL_CONSUMER[MAX_SDK_VERSION_LENGTH];
 CPullConsumer* CreatePullConsumer(const char* groupId) {
   if (groupId == NULL) {
     return NULL;
   }
   DefaultMQPullConsumer* defaultMQPullConsumer = new DefaultMQPullConsumer(groupId);
+  strncpy(VERSION_FOR_PULL_CONSUMER, defaultMQPullConsumer->version().c_str(), MAX_SDK_VERSION_LENGTH - 1);
+  VERSION_FOR_PULL_CONSUMER[MAX_SDK_VERSION_LENGTH - 1] = 0;
   return (CPullConsumer*)defaultMQPullConsumer;
 }
 int DestroyPullConsumer(CPullConsumer* consumer) {
@@ -61,6 +63,13 @@ int ShutdownPullConsumer(CPullConsumer* consumer) {
   ((DefaultMQPullConsumer*)consumer)->shutdown();
   return OK;
 }
+const char* ShowPullConsumerVersion(CPullConsumer* consumer) {
+  if (consumer == NULL) {
+    return NULL;
+  }
+  return VERSION_FOR_PULL_CONSUMER;
+}
+
 int SetPullConsumerGroupID(CPullConsumer* consumer, const char* groupId) {
   if (consumer == NULL || groupId == NULL) {
     return NULL_POINTER;

--- a/src/extern/CPushConsumer.cpp
+++ b/src/extern/CPushConsumer.cpp
@@ -85,13 +85,16 @@ map<CPushConsumer*, MessageListenerOrderlyInner*> g_OrderListenerMap;
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+char VERSION_FOR_PUSH_CONSUMER[MAX_SDK_VERSION_LENGTH];
 CPushConsumer* CreatePushConsumer(const char* groupId) {
   if (groupId == NULL) {
     return NULL;
   }
   DefaultMQPushConsumer* defaultMQPushConsumer = new DefaultMQPushConsumer(groupId);
   defaultMQPushConsumer->setConsumeFromWhere(CONSUME_FROM_LAST_OFFSET);
+
+  strncpy(VERSION_FOR_PUSH_CONSUMER, defaultMQPushConsumer->version().c_str(), MAX_SDK_VERSION_LENGTH - 1);
+  VERSION_FOR_PUSH_CONSUMER[MAX_SDK_VERSION_LENGTH - 1] = 0;
   return (CPushConsumer*)defaultMQPushConsumer;
 }
 int DestroyPushConsumer(CPushConsumer* consumer) {
@@ -119,6 +122,13 @@ int ShutdownPushConsumer(CPushConsumer* consumer) {
   }
   ((DefaultMQPushConsumer*)consumer)->shutdown();
   return OK;
+}
+
+const char* ShowPushConsumerVersion(CPushConsumer* consumer) {
+  if (consumer == NULL) {
+    return NULL;
+  }
+  return VERSION_FOR_PUSH_CONSUMER;
 }
 int SetPushConsumerGroupID(CPushConsumer* consumer, const char* groupId) {
   if (consumer == NULL || groupId == NULL) {

--- a/src/include/DefaultMQClient.h
+++ b/src/include/DefaultMQClient.h
@@ -175,6 +175,7 @@ class DefaultMQClient {
   virtual void shutdown();
   MQClientFactory* getFactory() const;
   virtual bool isServiceStateOk();
+  void showClientConfigs();
 
  protected:
   std::string m_namesrvAddr;

--- a/src/include/DefaultMQClient.h
+++ b/src/include/DefaultMQClient.h
@@ -41,6 +41,7 @@ class DefaultMQClient {
 
  public:
   // clientid=processId-ipAddr@instanceName;
+  std::string getClientVersionString() const;
   std::string getMQClientId() const;
   const std::string& getNamesrvAddr() const;
   void setNamesrvAddr(const std::string& namesrvAddr);

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -38,9 +38,11 @@ void DefaultMQProducer::shutdown() {
 }
 
 std::string DefaultMQProducer::version() {
-  std::string versions = impl->getClientVersionString() +
-                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
-                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  std::string versions = impl->getClientVersionString();
+  versions.append(", PROTOCOL VERSION: ")
+      .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
+      .append(", LANGUAGE: ")
+      .append(MQVersion::s_CurrentLanguage);
   return versions;
 }
 

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -39,10 +39,12 @@ void DefaultMQProducer::shutdown() {
 
 std::string DefaultMQProducer::version() {
   std::string versions = impl->getClientVersionString();
+  /*
   versions.append(", PROTOCOL VERSION: ")
       .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
       .append(", LANGUAGE: ")
       .append(MQVersion::s_CurrentLanguage);
+  */
   return versions;
 }
 

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "DefaultMQProducer.h"
+#include <MQVersion.h>
 
 #include "DefaultMQProducerImpl.h"
 
@@ -34,6 +35,13 @@ void DefaultMQProducer::start() {
 
 void DefaultMQProducer::shutdown() {
   impl->shutdown();
+}
+
+std::string DefaultMQProducer::version() {
+  std::string versions = impl->getClientVersionString() +
+                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
+                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  return versions;
 }
 
 // start mqclient set

--- a/src/producer/DefaultMQProducerImpl.cpp
+++ b/src/producer/DefaultMQProducerImpl.cpp
@@ -63,6 +63,7 @@ void DefaultMQProducerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
+  LOG_INFO("###Current Producer@", getClientVersionString().c_str());
   // we should deal with namespaced before start.
   dealWithNameSpace();
   switch (m_serviceState) {

--- a/src/producer/DefaultMQProducerImpl.cpp
+++ b/src/producer/DefaultMQProducerImpl.cpp
@@ -63,7 +63,7 @@ void DefaultMQProducerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
-  LOG_INFO("###Current Producer@", getClientVersionString().c_str());
+  LOG_INFO("###Current Producer@%s", getClientVersionString().c_str());
   // we should deal with namespaced before start.
   dealWithNameSpace();
   switch (m_serviceState) {

--- a/src/producer/DefaultMQProducerImpl.cpp
+++ b/src/producer/DefaultMQProducerImpl.cpp
@@ -63,9 +63,10 @@ void DefaultMQProducerImpl::start() {
   sa.sa_flags = 0;
   sigaction(SIGPIPE, &sa, 0);
 #endif
-  LOG_INFO("###Current Producer@%s", getClientVersionString().c_str());
+  LOG_WARN("###Current Producer@%s", getClientVersionString().c_str());
   // we should deal with namespaced before start.
   dealWithNameSpace();
+  logConfigs();
   switch (m_serviceState) {
     case CREATE_JUST: {
       m_serviceState = START_FAILED;
@@ -634,6 +635,16 @@ bool DefaultMQProducerImpl::dealWithNameSpace() {
     setGroupName(fullGID);
   }
   return true;
+}
+void DefaultMQProducerImpl::logConfigs() {
+  showClientConfigs();
+
+  LOG_WARN("SendMsgTimeout:%d ms", m_sendMsgTimeout);
+  LOG_WARN("CompressMsgBodyOverHowmuch:%d", m_compressMsgBodyOverHowmuch);
+  LOG_WARN("MaxMessageSize:%d", m_maxMessageSize);
+  LOG_WARN("CompressLevel:%d", m_compressLevel);
+  LOG_WARN("RetryTimes:%d", m_retryTimes);
+  LOG_WARN("RetryTimes4Async:%d", m_retryTimes4Async);
 }
 //<!***************************************************************************
 }  // namespace rocketmq

--- a/src/producer/DefaultMQProducerImpl.h
+++ b/src/producer/DefaultMQProducerImpl.h
@@ -103,6 +103,7 @@ class DefaultMQProducerImpl : public MQProducer {
   bool tryToCompressMessage(MQMessage& msg);
   BatchMessage buildBatchMessage(std::vector<MQMessage>& msgs);
   bool dealWithNameSpace();
+  void logConfigs();
 
  private:
   int m_sendMsgTimeout;

--- a/src/producer/TransactionMQProducer.cpp
+++ b/src/producer/TransactionMQProducer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "TransactionMQProducer.h"
+#include <MQVersion.h>
 
 #include "TransactionMQProducerImpl.h"
 
@@ -35,7 +36,12 @@ void TransactionMQProducer::start() {
 void TransactionMQProducer::shutdown() {
   impl->shutdown();
 }
-
+std::string TransactionMQProducer::version() {
+  std::string versions = impl->getClientVersionString() +
+                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
+                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  return versions;
+}
 // start mqclient set
 const std::string& TransactionMQProducer::getNamesrvAddr() const {
   return impl->getNamesrvAddr();

--- a/src/producer/TransactionMQProducer.cpp
+++ b/src/producer/TransactionMQProducer.cpp
@@ -37,9 +37,11 @@ void TransactionMQProducer::shutdown() {
   impl->shutdown();
 }
 std::string TransactionMQProducer::version() {
-  std::string versions = impl->getClientVersionString() +
-                         ", PROTOCOL VERSION:" + MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion) +
-                         ", LANGUAGE: " + MQVersion::s_CurrentLanguage;
+  std::string versions = impl->getClientVersionString();
+  versions.append(", PROTOCOL VERSION: ")
+      .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
+      .append(", LANGUAGE: ")
+      .append(MQVersion::s_CurrentLanguage);
   return versions;
 }
 // start mqclient set

--- a/src/producer/TransactionMQProducer.cpp
+++ b/src/producer/TransactionMQProducer.cpp
@@ -38,10 +38,12 @@ void TransactionMQProducer::shutdown() {
 }
 std::string TransactionMQProducer::version() {
   std::string versions = impl->getClientVersionString();
+  /*
   versions.append(", PROTOCOL VERSION: ")
       .append(MQVersion::GetVersionDesc(MQVersion::s_CurrentVersion))
       .append(", LANGUAGE: ")
       .append(MQVersion::s_CurrentLanguage);
+  */
   return versions;
 }
 // start mqclient set

--- a/src/protocol/ConsumerRunningInfo.cpp
+++ b/src/protocol/ConsumerRunningInfo.cpp
@@ -23,7 +23,7 @@ const string ConsumerRunningInfo::PROP_THREADPOOL_CORE_SIZE = "PROP_THREADPOOL_C
 const string ConsumerRunningInfo::PROP_CONSUME_ORDERLY = "PROP_CONSUMEORDERLY";
 const string ConsumerRunningInfo::PROP_CONSUME_TYPE = "PROP_CONSUME_TYPE";
 const string ConsumerRunningInfo::PROP_CLIENT_VERSION = "PROP_CLIENT_VERSION";
-const string ConsumerRunningInfo::PROP_CLIENT_SDK_VERSION = "PROP_CLIENT_SDK_VERSION";
+const string ConsumerRunningInfo::PROP_CLIENT_SDK_VERSION = "PROP_CLIENT_CORE_VERSION";
 const string ConsumerRunningInfo::PROP_CONSUMER_START_TIMESTAMP = "PROP_CONSUMER_START_TIMESTAMP";
 
 const map<string, string> ConsumerRunningInfo::getProperties() const {

--- a/src/protocol/ConsumerRunningInfo.cpp
+++ b/src/protocol/ConsumerRunningInfo.cpp
@@ -1,19 +1,19 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "ConsumerRunningInfo.h"
 #include "UtilAll.h"
 
@@ -23,6 +23,7 @@ const string ConsumerRunningInfo::PROP_THREADPOOL_CORE_SIZE = "PROP_THREADPOOL_C
 const string ConsumerRunningInfo::PROP_CONSUME_ORDERLY = "PROP_CONSUMEORDERLY";
 const string ConsumerRunningInfo::PROP_CONSUME_TYPE = "PROP_CONSUME_TYPE";
 const string ConsumerRunningInfo::PROP_CLIENT_VERSION = "PROP_CLIENT_VERSION";
+const string ConsumerRunningInfo::PROP_CLIENT_SDK_VERSION = "PROP_CLIENT_SDK_VERSION";
 const string ConsumerRunningInfo::PROP_CONSUMER_START_TIMESTAMP = "PROP_CONSUMER_START_TIMESTAMP";
 
 const map<string, string> ConsumerRunningInfo::getProperties() const {
@@ -82,6 +83,7 @@ string ConsumerRunningInfo::encode() {
   outData[PROP_CONSUMER_START_TIMESTAMP] = properties[PROP_CONSUMER_START_TIMESTAMP];
   outData[PROP_CONSUME_ORDERLY] = properties[PROP_CONSUME_ORDERLY];
   outData[PROP_THREADPOOL_CORE_SIZE] = properties[PROP_THREADPOOL_CORE_SIZE];
+  outData[PROP_CLIENT_SDK_VERSION] = properties[PROP_CLIENT_SDK_VERSION];
 
   Json::Value root;
   root["jstack"] = jstack;
@@ -116,4 +118,4 @@ string ConsumerRunningInfo::encode() {
 
   return finals;
 }
-}
+}  // namespace rocketmq

--- a/src/protocol/ConsumerRunningInfo.h
+++ b/src/protocol/ConsumerRunningInfo.h
@@ -1,19 +1,19 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef __CONSUMERRUNNINGINFO_H__
 #define __CONSUMERRUNNINGINFO_H__
 
@@ -38,6 +38,7 @@ class ConsumerRunningInfo {
   static const string PROP_CONSUME_ORDERLY;
   static const string PROP_CONSUME_TYPE;
   static const string PROP_CLIENT_VERSION;
+  static const string PROP_CLIENT_SDK_VERSION;
   static const string PROP_CONSUMER_START_TIMESTAMP;
 
  public:
@@ -61,5 +62,5 @@ class ConsumerRunningInfo {
   // map<string, ConsumeStatus> statusTable;
   string jstack;
 };
-}
+}  // namespace rocketmq
 #endif

--- a/src/transport/TcpRemotingClient.cpp
+++ b/src/transport/TcpRemotingClient.cpp
@@ -28,6 +28,8 @@
 namespace rocketmq {
 
 //<!************************************************************************
+TcpRemotingClient::TcpRemotingClient()
+    : m_dispatchServiceWork(m_dispatchService), m_handleServiceWork(m_handleService) {}
 TcpRemotingClient::TcpRemotingClient(int pullThreadNum, uint64_t tcpConnectTimeout, uint64_t tcpTransportTryLockTimeout)
     : m_dispatchThreadNum(1),
       m_pullThreadNum(pullThreadNum),

--- a/src/transport/TcpRemotingClient.h
+++ b/src/transport/TcpRemotingClient.h
@@ -36,6 +36,7 @@ namespace rocketmq {
 
 class TcpRemotingClient {
  public:
+  TcpRemotingClient();
   TcpRemotingClient(int pullThreadNum, uint64_t tcpConnectTimeout, uint64_t tcpTransportTryLockTimeout);
   virtual ~TcpRemotingClient();
 

--- a/test/src/MQClientAPIImpTest.cpp
+++ b/test/src/MQClientAPIImpTest.cpp
@@ -35,8 +35,7 @@ using testing::Return;
 
 class MockTcpRemotingClient : public TcpRemotingClient {
  public:
-  MockTcpRemotingClient(int pullThreadNum, uint64_t tcpConnectTimeout, uint64_t tcpTransportTryLockTimeout)
-      : TcpRemotingClient(pullThreadNum, tcpConnectTimeout, tcpTransportTryLockTimeout) {}
+  MockTcpRemotingClient() : TcpRemotingClient() {}
 
   MOCK_METHOD3(invokeSync, RemotingCommand*(const string&, RemotingCommand&, int));
   MOCK_METHOD6(invokeAsync, bool(const string&, RemotingCommand&, std::shared_ptr<AsyncCallbackWrap>, int64, int, int));
@@ -49,60 +48,17 @@ class MockMQClientAPIImpl : public MQClientAPIImpl {
                       uint64_t tcpConnectTimeout,
                       uint64_t tcpTransportTryLockTimeout,
                       string unitName)
-      : MQClientAPIImpl(mqClientId,
-                        clientRemotingProcessor,
-                        pullThreadNum,
-                        tcpConnectTimeout,
-                        tcpTransportTryLockTimeout,
-                        unitName) {
-    m_processor = clientRemotingProcessor;
-  }
-  ClientRemotingProcessor* m_processor;
-  void reInitRemoteClient(TcpRemotingClient* client) {
-    m_pRemotingClient.reset(client);
-    m_pRemotingClient->registerProcessor(CHECK_TRANSACTION_STATE, m_processor);
-    m_pRemotingClient->registerProcessor(RESET_CONSUMER_CLIENT_OFFSET, m_processor);
-    m_pRemotingClient->registerProcessor(GET_CONSUMER_STATUS_FROM_CLIENT, m_processor);
-    m_pRemotingClient->registerProcessor(GET_CONSUMER_RUNNING_INFO, m_processor);
-    m_pRemotingClient->registerProcessor(NOTIFY_CONSUMER_IDS_CHANGED, m_processor);
-    m_pRemotingClient->registerProcessor(CONSUME_MESSAGE_DIRECTLY, m_processor);
-  }
-};
-class MockMQClientAPIImplUtil {
- public:
-  static MockMQClientAPIImplUtil* GetInstance() {
-    static MockMQClientAPIImplUtil instance;
-    return &instance;
-  }
-  MockMQClientAPIImpl* GetGtestMockClientAPIImpl() {
-    if (m_impl != nullptr) {
-      return m_impl;
-    }
-    string cid = "testClientId";
-    int ptN = 1;
-    uint64_t tct = 3000;
-    uint64_t ttt = 3000;
-    string un = "central";
-    SessionCredentials sc;
-    ClientRemotingProcessor* pp = new ClientRemotingProcessor(nullptr);
-    MockMQClientAPIImpl* impl = new MockMQClientAPIImpl(cid, pp, ptN, tct, ttt, un);
-    MockTcpRemotingClient* pClient = new MockTcpRemotingClient(ptN, tct, ttt);
-    impl->reInitRemoteClient(pClient);
-    m_impl = impl;
-    m_pClient = pClient;
-    return impl;
-  }
-  MockTcpRemotingClient* GetGtestMockRemotingClient() { return m_pClient; }
-  MockMQClientAPIImpl* m_impl = nullptr;
-  MockTcpRemotingClient* m_pClient = nullptr;
+      : MQClientAPIImpl(mqClientId) {}
+  void reInitRemoteClient(TcpRemotingClient* client) { m_pRemotingClient.reset(client); }
 };
 
 TEST(MQClientAPIImplTest, getMaxOffset) {
   SessionCredentials sc;
-  MockMQClientAPIImpl* impl = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockClientAPIImpl();
+  MockMQClientAPIImpl* impl = new MockMQClientAPIImpl("testMockAPIImpl", nullptr, 1, 2, 3, "testUnit");
   Mock::AllowLeak(impl);
-  MockTcpRemotingClient* pClient = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockRemotingClient();
+  MockTcpRemotingClient* pClient = new MockTcpRemotingClient();
   Mock::AllowLeak(pClient);
+  impl->reInitRemoteClient(pClient);
   GetMaxOffsetResponseHeader* pHead = new GetMaxOffsetResponseHeader();
   pHead->offset = 4096;
   RemotingCommand* pCommandFailed = new RemotingCommand(SYSTEM_ERROR, nullptr);
@@ -120,10 +76,11 @@ TEST(MQClientAPIImplTest, getMaxOffset) {
 
 TEST(MQClientAPIImplTest, getMinOffset) {
   SessionCredentials sc;
-  MockMQClientAPIImpl* impl = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockClientAPIImpl();
+  MockMQClientAPIImpl* impl = new MockMQClientAPIImpl("testMockAPIImpl", nullptr, 1, 2, 3, "testUnit");
   Mock::AllowLeak(impl);
-  MockTcpRemotingClient* pClient = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockRemotingClient();
+  MockTcpRemotingClient* pClient = new MockTcpRemotingClient();
   Mock::AllowLeak(pClient);
+  impl->reInitRemoteClient(pClient);
   GetMinOffsetResponseHeader* pHead = new GetMinOffsetResponseHeader();
   pHead->offset = 2048;
   RemotingCommand* pCommandFailed = new RemotingCommand(SYSTEM_ERROR, nullptr);
@@ -154,11 +111,11 @@ class MyMockAutoDeleteSendCallback : public AutoDeleteSendCallBack {
 TEST(MQClientAPIImplTest, sendMessage) {
   string cid = "testClientId";
   SessionCredentials sc;
-  MockMQClientAPIImpl* impl = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockClientAPIImpl();
+  MockMQClientAPIImpl* impl = new MockMQClientAPIImpl("testMockAPIImpl", nullptr, 1, 2, 3, "testUnit");
   Mock::AllowLeak(impl);
-  MockTcpRemotingClient* pClient = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockRemotingClient();
+  MockTcpRemotingClient* pClient = new MockTcpRemotingClient();
   Mock::AllowLeak(pClient);
-
+  impl->reInitRemoteClient(pClient);
   SendMessageResponseHeader* pHead = new SendMessageResponseHeader();
   pHead->msgId = "MessageID";
   pHead->queueId = 1;
@@ -238,10 +195,11 @@ TEST(MQClientAPIImplTest, sendMessage) {
 TEST(MQClientAPIImplTest, consumerSendMessageBack) {
   SessionCredentials sc;
   MQMessageExt msg;
-  MockMQClientAPIImpl* impl = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockClientAPIImpl();
+  MockMQClientAPIImpl* impl = new MockMQClientAPIImpl("testMockAPIImpl", nullptr, 1, 2, 3, "testUnit");
   Mock::AllowLeak(impl);
-  MockTcpRemotingClient* pClient = MockMQClientAPIImplUtil::GetInstance()->GetGtestMockRemotingClient();
+  MockTcpRemotingClient* pClient = new MockTcpRemotingClient();
   Mock::AllowLeak(pClient);
+  impl->reInitRemoteClient(pClient);
   RemotingCommand* pCommandFailed = new RemotingCommand(SYSTEM_ERROR, nullptr);
   RemotingCommand* pCommandSuccuss = new RemotingCommand(SUCCESS_VALUE, nullptr);
   EXPECT_CALL(*pClient, invokeSync(_, _, _))

--- a/test/src/extern/CProducerTest.cpp
+++ b/test/src/extern/CProducerTest.cpp
@@ -247,7 +247,21 @@ TEST(cProducer, null) {
   EXPECT_EQ(SetProducerLogLevel(NULL, E_LOG_LEVEL_FATAL), NULL_POINTER);
   EXPECT_EQ(DestroyProducer(NULL), NULL_POINTER);
 }
+TEST(cProducer, version) {
+  CProducer* cProducer = CreateProducer("groupTestVersion");
+  EXPECT_TRUE(cProducer != NULL);
+  string version(ShowProducerVersion(cProducer));
+  EXPECT_GT(version.length(), 0);
+  CProducer* cProducer2 = CreateOrderlyProducer("orderGroupTestVersion");
+  EXPECT_TRUE(cProducer2 != NULL);
+  string version2(ShowProducerVersion(cProducer2));
+  EXPECT_GT(version2.length(), 0);
 
+  CProducer* cProducer3 = CreateTransactionProducer("tranGroupTestVersion", NULL, NULL);
+  EXPECT_TRUE(cProducer3 != NULL);
+  string version3(ShowProducerVersion(cProducer3));
+  EXPECT_GT(version3.length(), 0);
+}
 int main(int argc, char* argv[]) {
   InitGoogleMock(&argc, argv);
   testing::GTEST_FLAG(throw_on_failure) = true;

--- a/test/src/extern/CPullConsumerTest.cpp
+++ b/test/src/extern/CPullConsumerTest.cpp
@@ -196,7 +196,12 @@ TEST(cpullConsumer, null) {
   EXPECT_EQ(StartPullConsumer(NULL), NULL_POINTER);
   EXPECT_EQ(ShutdownPullConsumer(NULL), NULL_POINTER);
 }
-
+TEST(cpullConsumer, version) {
+  CPullConsumer* pullConsumer = CreatePullConsumer("groupTestVersion");
+  EXPECT_TRUE(pullConsumer != NULL);
+  string version(ShowPullConsumerVersion(pullConsumer));
+  EXPECT_GT(version.length(), 0);
+}
 int main(int argc, char* argv[]) {
   InitGoogleMock(&argc, argv);
   testing::GTEST_FLAG(throw_on_failure) = true;

--- a/test/src/extern/CPushConsumerTest.cpp
+++ b/test/src/extern/CPushConsumerTest.cpp
@@ -147,7 +147,12 @@ TEST(cPushComsumer, null) {
   EXPECT_EQ(SetPushConsumerLogLevel(NULL, E_LOG_LEVEL_LEVEL_NUM), NULL_POINTER);
   EXPECT_EQ(SetPushConsumerMessageModel(NULL, BROADCASTING), NULL_POINTER);
 }
-
+TEST(cPushComsumer, version) {
+  CPushConsumer* pushConsumer = CreatePushConsumer("groupTestVersion");
+  EXPECT_TRUE(pushConsumer != NULL);
+  string version(ShowPushConsumerVersion(pushConsumer));
+  EXPECT_GT(version.length(), 0);
+}
 int main(int argc, char* argv[]) {
   InitGoogleMock(&argc, argv);
   testing::GTEST_FLAG(filter) = "cPushComsumer.*";

--- a/test/src/protocol/ConsumerRunningInfoTest.cpp
+++ b/test/src/protocol/ConsumerRunningInfoTest.cpp
@@ -99,6 +99,7 @@ TEST(ConsumerRunningInfo, init) {
   info.setProperty(ConsumerRunningInfo::PROP_CONSUME_TYPE, "consume_type");
   info.setProperty(ConsumerRunningInfo::PROP_CLIENT_VERSION, "client_version");
   info.setProperty(ConsumerRunningInfo::PROP_CONSUMER_START_TIMESTAMP, "127");
+  info.setProperty(ConsumerRunningInfo::PROP_CLIENT_SDK_VERSION, "sdk_version");
 
   // encode
   string outStr = info.encode();


### PR DESCRIPTION
## What is the purpose of the change

add api to get SDK versions
CPP API: version()
C API: ShowProducerVersion()... and so on.

you can get SDK version strings like this:
`CPP CORE VERSION: 2.0.0, BUILD TIME: 19:30:30 02-14-2020`

## Brief changelog
feat(version): add api to get SDK versions
