### PR TITLE
fix(memory): heap-buffer-overflow due to wrong use of strcpy.

### DIFF
--- a/test/src/common/big_endianTest.cpp
+++ b/test/src/common/big_endianTest.cpp
@@ -62,7 +62,7 @@ TEST(big_endian, bigEndianObject) {
 
   char* newBuf = (char*)malloc(sizeof(char) * 8);
   char* writeBuf = (char*)malloc(sizeof(char) * 8);
-  strcpy(writeBuf, "RocketMQ");
+  strncpy(writeBuf, "RocketMQ", 8);
   EXPECT_TRUE(writer.WriteBytes(writeBuf, (size_t)8));
   EXPECT_TRUE(reader.ReadBytes(newBuf, (size_t)8));
   EXPECT_EQ(*writeBuf, *newBuf);
@@ -76,7 +76,7 @@ TEST(big_endian, bigEndian) {
 
   /*TODO
       char *newBuf = (char *) malloc(sizeof(char) * 8);
-      strcpy(newBuf, "RocketMQ");
+      strncpy(newBuf, "RocketMQ", 8);
 
       char readBuf[8];
       rocketmq::WriteBigEndian(writeBuf, newBuf);


### PR DESCRIPTION
## What is the purpose of the change

Fix heap-buffer-overflow due to wrong use of strcpy.

## Brief changelog

Fix heap-buffer-overflow due to wrong use of strcpy.

## Verifying this change

Verified. Want a code review.

## The ASAN Report

==45669==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000ed10 at pc 0x4dc0a5 bp 0x7ffee848e850 sp 0x7ffee848e848
WRITE of size 9 at 0x60200000ed10 thread T0
    #0 0x4dc0a4 in big_endian_bigEndianObject_Test::TestBody() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dc0a4)
    #1 0x50c7fd in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50c7fd)
    #2 0x50652b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50652b)
    #3 0x4e6b36 in testing::Test::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e6b36)
    #4 0x4e73fd in testing::TestInfo::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e73fd)
    #5 0x4e7ac1 in testing::TestCase::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e7ac1)
    #6 0x4f22c4 in testing::internal::UnitTestImpl::RunAllTests() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4f22c4)
    #7 0x50dbfb in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50dbfb)
    #8 0x5072ad in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x5072ad)
    #9 0x4f0d6a in testing::UnitTest::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4f0d6a)
    #10 0x4dd15d in RUN_ALL_TESTS() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dd15d)
    #11 0x4dcbde in main (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dcbde)
    #12 0x7fef534fa444 in __libc_start_main (/lib64/libc.so.6+0x22444)
    #13 0x478108 (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x478108)

0x60200000ed18 is located 0 bytes to the right of 8-byte region [0x60200000ed10,0x60200000ed18)
allocated by thread T0 here:
    #0 0x4b2e9f in malloc (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4b2e9f)
    #1 0x4dbfbf in big_endian_bigEndianObject_Test::TestBody() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dbfbf)
    #2 0x50c7fd in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50c7fd)
    #3 0x50652b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50652b)
    #4 0x4e6b36 in testing::Test::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e6b36)
    #5 0x4e73fd in testing::TestInfo::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e73fd)
    #6 0x4e7ac1 in testing::TestCase::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4e7ac1)
    #7 0x4f22c4 in testing::internal::UnitTestImpl::RunAllTests() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4f22c4)
    #8 0x50dbfb in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x50dbfb)
    #9 0x5072ad in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x5072ad)
    #10 0x4f0d6a in testing::UnitTest::Run() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4f0d6a)
    #11 0x4dd15d in RUN_ALL_TESTS() (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dd15d)
    #12 0x4dcbde in main (/home/yizhe.wcm/PR/rocketmq-client-cpp/test/bin/big_endianTest+0x4dcbde)
    #13 0x7fef534fa444 in __libc_start_main (/lib64/libc.so.6+0x22444)

SUMMARY: AddressSanitizer: heap-buffer-overflow ??:0 big_endian_bigEndianObject_Test::TestBody()
Shadow bytes around the buggy address:
  0x0c047fff9d50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9d90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c047fff9da0: fa fa[00]fa fa fa 00 fa fa fa fd fa fa fa fd fa
  0x0c047fff9db0: fa fa fd fa fa fa fd fa fa fa 00 00 fa fa 00 fa
  0x0c047fff9dc0: fa fa fd fa fa fa 00 fa fa fa 00 fa fa fa 00 fa
  0x0c047fff9dd0: fa fa 00 00 fa fa 00 fa fa fa fd fa fa fa fd fa
  0x0c047fff9de0: fa fa 04 fa fa fa 00 fa fa fa 00 fa fa fa 00 fa
  0x0c047fff9df0: fa fa 00 fa fa fa 00 fa fa fa 00 00 fa fa 00 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==45669==ABORTING

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
