### PR TITLE
refactor(build): use dynamic cpu cores to compile code.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ PrintParams() {
   echo ""
 }
 
+declare cpu_num=$(cat /proc/cpuinfo | grep "processor" | wc -l)
 declare need_build_jsoncpp=1
 declare need_build_libevent=1
 declare need_build_boost=1
@@ -46,7 +47,6 @@ declare enable_asan=0
 declare enable_lsan=0
 declare verbose=1
 declare codecov=0
-declare cpu_num=4
 declare test=0
 
 pasres_arguments() {

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,11 @@ PrintParams() {
   echo ""
 }
 
-declare cpu_num=$(cat /proc/cpuinfo | grep "processor" | wc -l)
+if test "$(uname)" = "Linux"; then
+  declare cpu_num=$(cat /proc/cpuinfo | grep "processor" | wc -l)
+elif test "$(uname)" = "Darwin" ; then
+  declare cpu_num=$(sysctl -n machdep.cpu.thread_count)
+fi
 declare need_build_jsoncpp=1
 declare need_build_libevent=1
 declare need_build_boost=1


### PR DESCRIPTION
## What is the purpose of the change

Modify the default number of threads used for compilation on Linux and MAC platforms to be the number of CPU logical cores, rather than hardcode.

## Brief changelog

Modify the default number of threads used for compilation on Linux and MAC platforms to be the number of CPU logical cores, rather than hardcode.

## Verifying this change

Verified. Want a code review.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
