### PR TITLE
[ISSUE #282] modify the time out set of the sendmessageback function.

### DIFF
--- a/src/consumer/DefaultMQPushConsumerImpl.cpp
+++ b/src/consumer/DefaultMQPushConsumerImpl.cpp
@@ -259,8 +259,8 @@ bool DefaultMQPushConsumerImpl::sendMessageBack(MQMessageExt& msg, int delayLeve
   else
     brokerAddr = socketAddress2IPPort(msg.getStoreHost());
   try {
-    getFactory()->getMQClientAPIImpl()->consumerSendMessageBack(brokerAddr, msg, getGroupName(), delayLevel,
-                                                                getMaxReconsumeTimes(), 3000, getSessionCredentials());
+    getFactory()->getMQClientAPIImpl()->consumerSendMessageBack(brokerAddr, msg, getGroupName(), delayLevel, 3000,
+                                                                getMaxReconsumeTimes(), getSessionCredentials());
   } catch (MQException& e) {
     LOG_ERROR(e.what());
     return false;


### PR DESCRIPTION
Close #282  send message back failed some time because timeout set to short.

## What is the purpose of the change

modify the time out set of the sendmessageback function.

## Brief changelog

