### PR TITLE
[ISSUE #296] Use the archive download URL for OpenSSL to avoid fail to download

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -212,7 +212,7 @@ BuildOpenSSL() {
   if [ -e ${fname_openssl} ]; then
     echo "${fname_openssl} is exist"
   else
-    wget https://www.openssl.org/source/${fname_openssl_down} -O ${fname_openssl_down}
+    wget https://www.openssl.org/source/old/1.1.1/${fname_openssl_down} -O ${fname_openssl_down}
   fi
   tar -zxvf ${fname_openssl} &> unzipopenssl.txt
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Use the archive download URL for OpenSSL to avoid fail to download