### PR TITLE
Add rocketmq libpath to ldconf to support dlopen in CentOS

### DIFF
--- a/rpm/rocketmq_x64/CENTOS/rocketmq-client-cpp.spec
+++ b/rpm/rocketmq_x64/CENTOS/rocketmq-client-cpp.spec
@@ -57,6 +57,11 @@ cp -f ${RPM_SOURCE_DIR}/rocketmq/bin/librocketmq.so     $RPM_BUILD_ROOT%{_prefix
 cp -f ${RPM_SOURCE_DIR}/rocketmq/bin/librocketmq.a     $RPM_BUILD_ROOT%{_prefix}/lib
 cp -rf ${RPM_SOURCE_DIR}/rocketmq/include/*             $RPM_BUILD_ROOT%{_prefix}/include/rocketmq
 
+%post
+# As '/usr/local/lib' is not included in dynamic libraries on CentOS, it should be made explicit to dlopen() 
+echo "/usr/local/lib" > /etc/ld.so.conf.d/librocketmq.x86_64.conf
+/sbin/ldconfig
+
 # package information
 %files
 # set file attribute here


### PR DESCRIPTION
## What is the purpose of the change

fix bug in rpm spec

## Brief changelog

make librocketmq.so accessible to dlopen()

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
