### PR TITLE
fixed incorrect delete operator

### DIFF
--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -273,7 +273,7 @@ int DestroyProducer(CProducer* pProducer) {
   }
   DefaultProducer* defaultMQProducer = (DefaultProducer*)pProducer;
   if (defaultMQProducer->version != NULL) {
-    delete defaultMQProducer->version;
+    delete[] defaultMQProducer->version;
     defaultMQProducer->version = NULL;
   }
   if (CAPI_C_PRODUCER_TYPE_TRANSACTION == defaultMQProducer->producerType) {


### PR DESCRIPTION
## What is the purpose of the change

Fix error - incorrect memory free - (operator new [] vs operator delete)


## Brief changelog

When version variable is allocated using new [] operator the memory release should be done using delete[] operator.

## Verifying this change

Line 228 of CProducer.cpp is:
  defaultMQProducer->version = new char[MAX_SDK_VERSION_LENGTH];

Memory release is in line 276:
    delete defaultMQProducer->version;

Should be:
    delete[] defaultMQProducer->version;


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
