### PR TITLE
make log dir configurable and make log name compatible with RocketMQ main project

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ declare fname_boost="boost*.tar.gz"
 declare fname_openssl_down="openssl-1.1.1d.tar.gz"
 declare fname_libevent_down="release-2.1.11-stable.zip"
 declare fname_jsoncpp_down="0.10.7.zip"
-declare fname_boost_down="1.58.0/boost_1_58_0.tar.gz"
+declare fname_boost_down="1.78.0/boost_1_78_0.tar.gz"
 
 PrintParams() {
   echo "=========================================one key build help============================================"

--- a/src/common/ByteOrder.h
+++ b/src/common/ByteOrder.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <algorithm>
-#include <boost/detail/endian.hpp>
+#include <boost/endian/arithmetic.hpp>
 #include "RocketMQClient.h"
 #include "UtilAll.h"
 //==============================================================================

--- a/src/common/UtilAll.h
+++ b/src/common/UtilAll.h
@@ -67,6 +67,7 @@ const string DEFAULT_CLIENT_KEY_PASSWD = null;
 const string DEFAULT_CLIENT_KEY_FILE = "/etc/rocketmq/client.key";
 const string DEFAULT_CLIENT_CERT_FILE = "/etc/rocketmq/client.pem";
 const string DEFAULT_CA_CERT_FILE = "/etc/rocketmq/ca.pem";
+const string ROCKETMQ_CLIENT_LOG_DIR = "ROCKETMQ_CLIENT_LOG_DIR";
 const string WS_ADDR =
     "please set nameserver domain by setDomainName, there is no default "
     "nameserver domain";

--- a/src/extern/CProducer.cpp
+++ b/src/extern/CProducer.cpp
@@ -687,6 +687,7 @@ int SetProducerLogPath(CProducer* producer, const char* logPath) {
   if (producer == NULL) {
     return NULL_POINTER;
   }
+  setenv(ROCKETMQ_CLIENT_LOG_DIR.c_str(), logPath, 1);
   return OK;
 }
 

--- a/src/extern/CPullConsumer.cpp
+++ b/src/extern/CPullConsumer.cpp
@@ -20,6 +20,7 @@
 #include "CMessageExt.h"
 #include "DefaultMQPullConsumer.h"
 #include "MQClientErrorContainer.h"
+#include "Logging.h"
 
 using namespace rocketmq;
 using namespace std;
@@ -114,6 +115,7 @@ int SetPullConsumerLogPath(CPullConsumer* consumer, const char* logPath) {
   }
   // Todo, This api should be implemented by core api.
   //((DefaultMQPullConsumer *) consumer)->setInstanceName(instanceName);
+  setenv(ROCKETMQ_CLIENT_LOG_DIR.c_str(), logPath, 1);
   return OK;
 }
 

--- a/src/extern/CPushConsumer.cpp
+++ b/src/extern/CPushConsumer.cpp
@@ -21,6 +21,7 @@
 #include "CMessageExt.h"
 #include "DefaultMQPushConsumer.h"
 #include "MQClientErrorContainer.h"
+#include "Logging.h"
 
 using namespace rocketmq;
 using namespace std;
@@ -278,6 +279,7 @@ int SetPushConsumerLogPath(CPushConsumer* consumer, const char* logPath) {
   }
   // Todo, This api should be implemented by core api.
   //((DefaultMQPushConsumer *) consumer)->setInstanceName(instanceName);
+  setenv(ROCKETMQ_CLIENT_LOG_DIR.c_str(), logPath, 1);
   return OK;
 }
 

--- a/src/log/Logging.h
+++ b/src/log/Logging.h
@@ -45,6 +45,7 @@ class logAdapter {
  public:
   ~logAdapter();
   static logAdapter* getLogInstance();
+  void setLogDir();
   void setLogLevel(elogLevel logLevel);
   elogLevel getLogLevel();
   void setLogFileNumAndSize(int logNum, int sizeOfPerFile);
@@ -60,6 +61,7 @@ class logAdapter {
   boost::shared_ptr<logSink_t> m_logSink;
   static logAdapter* alogInstance;
   static boost::mutex m_imtx;
+  std::string m_log_dir;
 };
 
 #define ALOG_ADAPTER logAdapter::getLogInstance()


### PR DESCRIPTION
## What is the purpose of the change

#400

## Brief changelog

Add the log path to the environment variable by using setenv function, and set this path before the log object is initialized.

## Verifying this change

By setting producer log path to "/logs/producer/cpp/", the log file was saved in "~/logs/producer/cpp/", and the main log file name is "rocketmq_client.log", backup log file name's format is "rocketmq_client_%Y%m%d-%N.log". As follows:

![image](https://user-images.githubusercontent.com/50660789/152913249-fbde5f35-fd13-4c79-b260-50eceb30a85e.png)


## MoreOver

We use boost1.78.0 to make backup log file name configurable.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
