### PR TITLE
avoid _WINSOCKAPI_ redefine error when include Windows.h and Winsock2.h at same time

### DIFF
--- a/include/MQMessageExt.h
+++ b/include/MQMessageExt.h
@@ -18,8 +18,11 @@
 #define __MESSAGEEXT_H__
 
 #ifdef WIN32
-#include <Windows.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Winsock2.h>
+#include <Windows.h>
 #else
 #include <sys/socket.h>
 #endif

--- a/src/common/ByteOrder.h
+++ b/src/common/ByteOrder.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <algorithm>
-#include <boost/detail/endian.hpp>
+#include <boost/endian.hpp>
 #include "RocketMQClient.h"
 #include "UtilAll.h"
 //==============================================================================

--- a/src/log/Logging.h
+++ b/src/log/Logging.h
@@ -30,7 +30,7 @@
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr.hpp>
 #include "include/DefaultMQClient.h"
 
 namespace logging = boost::log;

--- a/src/producer/StringIdMaker.cpp
+++ b/src/producer/StringIdMaker.cpp
@@ -125,11 +125,11 @@ std::string StringIdMaker::createUniqID() {
   return std::string(kFixString, 20) + std::string(hex_buf, 12);
 }
 
-void StringIdMaker::hexdump(unsigned char* in, char* out, std::size_t len) {
-  for (std::size_t i = 0; i < len; i++) {
-    unsigned char v = in[i];
-    out[i * 2] = sHexAlphabet[v >> 4];
-    out[i * 2 + 1] = sHexAlphabet[v & 0x0FU];
+void StringIdMaker::hexdump(unsigned char* buffer, char* out_buff, std::size_t index) {
+  for (std::size_t i = 0; i < index; i++) {
+    unsigned char v = buffer[i];
+    out_buff[i * 2] = sHexAlphabet[v >> 4];
+    out_buff[i * 2 + 1] = sHexAlphabet[v & 0x0FU];
   }
 }
 

--- a/src/producer/TransactionMQProducerImpl.h
+++ b/src/producer/TransactionMQProducerImpl.h
@@ -22,7 +22,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/weak_ptr.hpp>
+#include <boost/smart_ptr.hpp>
 #include <memory>
 #include <string>
 #include "DefaultMQProducerImpl.h"

--- a/src/transport/SocketUtil.h
+++ b/src/transport/SocketUtil.h
@@ -18,9 +18,12 @@
 #define __SOCKETUTIL_H__
 
 #ifdef WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <WS2tcpip.h>
-#include <Windows.h>
 #include <Winsock2.h>
+#include <Windows.h>
 #pragma comment(lib, "ws2_32.lib")
 #else
 #include <arpa/inet.h>

--- a/src/transport/TcpTransport.cpp
+++ b/src/transport/TcpTransport.cpp
@@ -207,7 +207,7 @@ void TcpTransport::eventCallback(BufferEvent* event, short what, TcpTransport* t
 
     // disable Nagle
     int val = 1;
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (void*)&val, sizeof(val));
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, static_cast<const char *>((void*)&val), sizeof(val));
     transport->setTcpConnectEvent(TCP_CONNECT_STATUS_SUCCESS);
   } else if (what & (BEV_EVENT_ERROR | BEV_EVENT_EOF | BEV_EVENT_READING | BEV_EVENT_WRITING)) {
     LOG_INFO("eventcb: received error event cb:%x on fd:%d", what, fd);


### PR DESCRIPTION
## What is the purpose of the change
fix compile error on windows

## Brief changelog

avoid _WINSOCKAPI_ redefine error when include Windows.h and Winsock2.h at same time

## Verifying this change
verified using "Visual Studio 17 2022 " 

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
