### PR TITLE
avoid _WINSOCKAPI_ redefine error when include Windows.h and Winsock2.h at same time

### DIFF
--- a/include/MQMessageExt.h
+++ b/include/MQMessageExt.h
@@ -18,8 +18,11 @@
 #define __MESSAGEEXT_H__
 
 #ifdef WIN32
-#include <Windows.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Winsock2.h>
+#include <Windows.h>
 #else
 #include <sys/socket.h>
 #endif

--- a/src/transport/SocketUtil.h
+++ b/src/transport/SocketUtil.h
@@ -18,9 +18,12 @@
 #define __SOCKETUTIL_H__
 
 #ifdef WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <WS2tcpip.h>
-#include <Windows.h>
 #include <Winsock2.h>
+#include <Windows.h>
 #pragma comment(lib, "ws2_32.lib")
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
(cherry picked from commit 6108dc5619a58c8b54e4604cb6dfedf5d2de74a1)

## What is the purpose of the change

fix possible socket compile error on windows

## Brief changelog

avoid _WINSOCKAPI_ redefine error when include Windows.h and Winsock2.h at same time

## Verifying this change

verified using "Visual Studio 17 2022"

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
