### PR TITLE
param “mq” is read only,pass by reference instead of value

### DIFF
--- a/src/transport/ClientRemotingProcessor.cpp
+++ b/src/transport/ClientRemotingProcessor.cpp
@@ -72,7 +72,7 @@ std::map<MQMessageQueue, int64> ResetOffsetBody::getOffsetTable() {
   return m_offsetTable;
 }
 
-void ResetOffsetBody::setOffsetTable(MQMessageQueue mq, int64 offset) {
+void ResetOffsetBody::setOffsetTable(const MQMessageQueue& mq, int64 offset) {
   m_offsetTable[mq] = offset;
 }
 

--- a/src/transport/ClientRemotingProcessor.h
+++ b/src/transport/ClientRemotingProcessor.h
@@ -43,7 +43,7 @@ class ResetOffsetBody {
  public:
   ResetOffsetBody() {}
   virtual ~ResetOffsetBody() { m_offsetTable.clear(); }
-  void setOffsetTable(MQMessageQueue mq, int64 offset);
+  void setOffsetTable(const MQMessageQueue& mq, int64 offset);
   std::map<MQMessageQueue, int64> getOffsetTable();
   static ResetOffsetBody* Decode(const MemoryBlock* mem);
 


### PR DESCRIPTION
(cherry picked from commit 57b584103a30ba1386560b8e54d209975ec7b055)

## What is the purpose of the change

optimize function call

## Brief changelog

param “mq” is read only,pass by reference instead of value

## Verifying this change

compile successful

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
