### PR TITLE
fixed memory leak: free address info after get it using evutil_getadd…

### DIFF
--- a/src/transport/TcpTransport.cpp
+++ b/src/transport/TcpTransport.cpp
@@ -126,6 +126,7 @@ u_long TcpTransport::getInetAddr(string& hostname) {
         }
       }
     }
+    evutil_freeaddrinfo(answer);
   }
 
   return addr;


### PR DESCRIPTION
Memory leak in TcpTransport::getInetAddr #430

## What is the purpose of the change
bugfix

## Brief changelog

> src/transport/TcpTransport.cpp

fix the meory leak caused by calling evutil_getaddrinfo without evutil_freeaddrinfo

Tested and Verified locally. 
