### PR TITLE
feat: add a flag to retry another broker when not store ok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.cache/
 cmake-build-debug/
 bin
 build

--- a/include/DefaultMQProducer.h
+++ b/include/DefaultMQProducer.h
@@ -98,6 +98,9 @@ class ROCKETMQCLIENT_API DefaultMQProducer {
   int getMaxMessageSize() const;
   void setMaxMessageSize(int maxMessageSize);
 
+  bool getRetryAnotherBrokerWhenNotStoreOK() const;
+  void setRetryAnotherBrokerWhenNotStoreOK(bool retry);
+
   int getRetryTimes() const;
   void setRetryTimes(int times);
 

--- a/src/producer/DefaultMQProducer.cpp
+++ b/src/producer/DefaultMQProducer.cpp
@@ -135,6 +135,14 @@ int DefaultMQProducer::getMaxMessageSize() const {
   return impl->getMaxMessageSize();
 }
 
+bool DefaultMQProducer::getRetryAnotherBrokerWhenNotStoreOK() const {
+  return impl->getRetryAnotherBrokerWhenNotStoreOK();
+}
+
+void DefaultMQProducer::setRetryAnotherBrokerWhenNotStoreOK(bool retry) {
+  impl->setRetryAnotherBrokerWhenNotStoreOK(retry);
+}
+
 void DefaultMQProducer::setRetryTimes4Async(int times) {
   impl->setRetryTimes4Async(times);
 }

--- a/src/producer/DefaultMQProducerImpl.cpp
+++ b/src/producer/DefaultMQProducerImpl.cpp
@@ -41,7 +41,7 @@ DefaultMQProducerImpl::DefaultMQProducerImpl(const string& groupname)
     : m_sendMsgTimeout(3000),
       m_compressMsgBodyOverHowmuch(4 * 1024),
       m_maxMessageSize(1024 * 128),
-      // m_retryAnotherBrokerWhenNotStoreOK(false),
+      m_retryAnotherBrokerWhenNotStoreOK(false),
       m_compressLevel(5),
       m_retryTimes(5),
       m_retryTimes4Async(1),
@@ -410,7 +410,7 @@ SendResult DefaultMQProducerImpl::sendDefaultImpl(MQMessage& msg,
           case ComMode_ONEWAY:
             return sendResult;
           case ComMode_SYNC:
-            if (sendResult.getSendStatus() != SEND_OK) {
+            if (sendResult.getSendStatus() != SEND_OK && m_retryAnotherBrokerWhenNotStoreOk) {
               if (bActiveMQ) {
                 topicPublishInfo->updateNonServiceMessageQueue(mq, getSendMsgTimeout());
               }
@@ -618,6 +618,14 @@ bool DefaultMQProducerImpl::tryToCompressMessage(MQMessage& msg) {
   }
 
   return false;
+}
+
+bool DefaultMQProducerImpl::getRetryAnotherBrokerWhenNotStoreOK() const {
+  return m_retryAnotherBrokerWhenNotStoreOK;
+}
+
+void DefaultMQProducerImpl::setRetryAnotherBrokerWhenNotStoreOK(bool retry) {
+  m_retryAnotherBrokerWhenNotStoreOK = retry;
 }
 
 int DefaultMQProducerImpl::getRetryTimes() const {

--- a/src/producer/DefaultMQProducerImpl.h
+++ b/src/producer/DefaultMQProducerImpl.h
@@ -84,6 +84,9 @@ class DefaultMQProducerImpl : public MQProducer {
   void setRetryTimes4Async(int times);
   void submitSendTraceRequest(const MQMessage& msg, SendCallback* pSendCallback);
 
+  bool getRetryAnotherBrokerWhenNotStoreOK() const;
+  void setRetryAnotherBrokerWhenNotStoreOK(bool retry);
+
  protected:
   SendResult sendAutoRetrySelectImpl(MQMessage& msg,
                                      MessageQueueSelector* pSelector,
@@ -122,7 +125,7 @@ class DefaultMQProducerImpl : public MQProducer {
   int m_sendMsgTimeout;
   int m_compressMsgBodyOverHowmuch;
   int m_maxMessageSize;  //<! default:128K;
-  // bool m_retryAnotherBrokerWhenNotStoreOK;
+  bool m_retryAnotherBrokerWhenNotStoreOK;
   int m_compressLevel;
   int m_retryTimes;
   int m_retryTimes4Async;


### PR DESCRIPTION
## What is the purpose of the change

add a flag to control whether to retry another broker when store is not okay.

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
