### PR TITLE
[ISSUE #458] change log module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,10 +79,18 @@ else ()
     #find_package(Boost 1.56 REQUIRED COMPONENTS atomic thread system chrono date_time log log_setup regex serialization filesystem locale iostreams) 
     set(Boost_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/bin/include)
     set(Boost_LIBRARY_DIRS ${PROJECT_SOURCE_DIR}/bin/lib)
-    set(Boost_LIBRARIES ${Boost_LIBRARY_DIRS}/libboost_atomic.a;${Boost_LIBRARY_DIRS}/libboost_thread.a;${Boost_LIBRARY_DIRS}/libboost_system.a;
-            ${Boost_LIBRARY_DIRS}/libboost_chrono.a;${Boost_LIBRARY_DIRS}/libboost_date_time.a;${Boost_LIBRARY_DIRS}/libboost_log.a;
-            ${Boost_LIBRARY_DIRS}/libboost_log_setup.a;${Boost_LIBRARY_DIRS}/libboost_regex.a;${Boost_LIBRARY_DIRS}/libboost_serialization.a;
-            ${Boost_LIBRARY_DIRS}/libboost_filesystem.a;${Boost_LIBRARY_DIRS}/libboost_locale.a;${Boost_LIBRARY_DIRS}/libboost_iostreams.a)
+    if (Boost_USE_STATIC_LIBS)
+        set(Boost_LIBRARIES ${Boost_LIBRARY_DIRS}/libboost_atomic.a;${Boost_LIBRARY_DIRS}/libboost_thread.a;${Boost_LIBRARY_DIRS}/libboost_system.a;
+                ${Boost_LIBRARY_DIRS}/libboost_chrono.a;${Boost_LIBRARY_DIRS}/libboost_date_time.a;${Boost_LIBRARY_DIRS}/libboost_log.a;
+                ${Boost_LIBRARY_DIRS}/libboost_log_setup.a;${Boost_LIBRARY_DIRS}/libboost_regex.a;${Boost_LIBRARY_DIRS}/libboost_serialization.a;
+                ${Boost_LIBRARY_DIRS}/libboost_filesystem.a;${Boost_LIBRARY_DIRS}/libboost_locale.a;${Boost_LIBRARY_DIRS}/libboost_iostreams.a)
+    else ()
+        set(Boost_LIBRARIES ${Boost_LIBRARY_DIRS}/libboost_atomic.so;${Boost_LIBRARY_DIRS}/libboost_thread.so;${Boost_LIBRARY_DIRS}/libboost_system.so;
+                    ${Boost_LIBRARY_DIRS}/libboost_chrono.so;${Boost_LIBRARY_DIRS}/libboost_date_time.so;${Boost_LIBRARY_DIRS}/libboost_log.so;
+                    ${Boost_LIBRARY_DIRS}/libboost_log_setup.so;${Boost_LIBRARY_DIRS}/libboost_regex.so;${Boost_LIBRARY_DIRS}/libboost_serialization.so;
+                    ${Boost_LIBRARY_DIRS}/libboost_filesystem.so;${Boost_LIBRARY_DIRS}/libboost_locale.so;${Boost_LIBRARY_DIRS}/libboost_iostreams.so)
+        add_definitions(-DBOOST_ALL_DYN_LINK)
+    endif ()
     include_directories(${Boost_INCLUDE_DIR})
 endif ()
 

--- a/src/log/Logging.cpp
+++ b/src/log/Logging.cpp
@@ -24,7 +24,10 @@ logAdapter* logAdapter::alogInstance;
 boost::mutex logAdapter::m_imtx;
 
 logAdapter::~logAdapter() {
-  logging::core::get()->remove_all_sinks();
+  //only remove current sink
+  logging::core::get()->remove_sik(m_logSink);
+  m_logSink->stop();
+  m_logSink->flush();
 }
 
 logAdapter* logAdapter::getLogInstance() {
@@ -39,7 +42,8 @@ logAdapter* logAdapter::getLogInstance() {
 
 logAdapter::logAdapter() : m_logLevel(eLOG_LEVEL_INFO) {
   setLogDir();
-  string homeDir(UtilAll::getHomeDirectory());
+  //use current dir
+  string homeDir;
   homeDir.append(m_log_dir);
   m_logFile += homeDir;
   std::string fileName = "rocketmq_client.log";
@@ -65,31 +69,32 @@ logAdapter::logAdapter() : m_logLevel(eLOG_LEVEL_INFO) {
 void logAdapter::setLogLevelInner(elogLevel logLevel) {
   switch (logLevel) {
     case eLOG_LEVEL_FATAL:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::fatal);
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::fatal);
       break;
     case eLOG_LEVEL_ERROR:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::error);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::error);
       break;
     case eLOG_LEVEL_WARN:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::warning);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::warning);
       break;
     case eLOG_LEVEL_INFO:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::info);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::info);
       break;
     case eLOG_LEVEL_DEBUG:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::debug);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::debug);
       break;
     case eLOG_LEVEL_TRACE:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::trace);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::trace);
       break;
     default:
-      logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::info);
-
+      //use current sink
+      m_logSink->set_filter(logging::trivial::severity >= logging::trivial::info);
       break;
   }
 }
@@ -117,7 +122,8 @@ void logAdapter::setLogDir() {
 }
 
 void logAdapter::setLogFileNumAndSize(int logNum, int sizeOfPerFile) {
-  string homeDir(UtilAll::getHomeDirectory());
+  //use current dir
+  string homeDir;
   homeDir.append(m_log_dir);
   m_logSink->locked_backend()->set_file_collector(sinks::file::make_collector(
       keywords::target = homeDir, keywords::max_size = logNum * sizeOfPerFile * 1024 * 1024));


### PR DESCRIPTION
## What is the purpose of the change

Multiple modules can use boost.log at the same time

## Brief changelog

1. Try to configure log on a single sink as much as possible
2. can use boost log shared library，Multiple modules use boost.log must use shared library



