### PR TITLE
[ISSUE #499] Fix log sharding bug

### DIFF
--- a/src/log/Logging.cpp
+++ b/src/log/Logging.cpp
@@ -119,6 +119,7 @@ void logAdapter::setLogDir() {
 void logAdapter::setLogFileNumAndSize(int logNum, int sizeOfPerFile) {
   string homeDir(UtilAll::getHomeDirectory());
   homeDir.append(m_log_dir);
+  m_logSink->locked_backend()->set_rotation_size(sizeOfPerFile * 1024 * 1024);
   m_logSink->locked_backend()->set_file_collector(sinks::file::make_collector(
       keywords::target = homeDir, keywords::max_size = logNum * sizeOfPerFile * 1024 * 1024));
 }


### PR DESCRIPTION
## What is the purpose of the change

related: https://github.com/apache/rocketmq-client-cpp/issues/499
Fix log sharding bug

## Brief changelog

The **set_file_collector** function only limits the size of all logs, the **set_rotation_size** function sets the size of a single log

## Verifying this change
 
after add the **set_rotation_size** function, log can be sharded.
![image](https://github.com/user-attachments/assets/ebe6682f-8893-4839-b4ea-1510d9f97238)
