### PR TITLE
[ISSUE #511] Gson serialization failed, commitOffset can be negative.

### DIFF
--- a/src/protocol/ProcessQueueInfo.h
+++ b/src/protocol/ProcessQueueInfo.h
@@ -42,9 +42,9 @@ class ProcessQueueInfo {
   virtual ~ProcessQueueInfo() {}
 
  public:
-  const uint64 getCommitOffset() const { return commitOffset; }
+  const int64 getCommitOffset() const { return commitOffset; }
 
-  void setCommitOffset(uint64 input_commitOffset) { commitOffset = input_commitOffset; }
+  void setCommitOffset(int64 input_commitOffset) { commitOffset = input_commitOffset; }
 
   void setLocked(bool in_locked) { locked = in_locked; }
 
@@ -56,7 +56,7 @@ class ProcessQueueInfo {
 
   Json::Value toJson() const {
     Json::Value outJson;
-    outJson["commitOffset"] = (UtilAll::to_string(commitOffset)).c_str();
+    outJson["commitOffset"] = (Json::Int64)commitOffset;
     outJson["cachedMsgMinOffset"] = (UtilAll::to_string(cachedMsgMinOffset)).c_str();
     outJson["cachedMsgMaxOffset"] = (UtilAll::to_string(cachedMsgMaxOffset)).c_str();
     outJson["cachedMsgCount"] = (int)(cachedMsgCount);
@@ -74,7 +74,7 @@ class ProcessQueueInfo {
   }
 
  public:
-  uint64 commitOffset;
+  int64 commitOffset;
   uint64 cachedMsgMinOffset;
   uint64 cachedMsgMaxOffset;
   int cachedMsgCount;

--- a/test/src/protocol/ProcessQueueInfoTest.cpp
+++ b/test/src/protocol/ProcessQueueInfoTest.cpp
@@ -54,7 +54,8 @@ TEST(processQueueInfo, init) {
 
   Json::Value outJson = processQueueInfo.toJson();
 
-  EXPECT_EQ(outJson["commitOffset"], "456");
+  EXPECT_TRUE(outJson["commitOffset"].isInt64());
+  EXPECT_EQ(outJson["commitOffset"].asInt64(), 456);
   EXPECT_EQ(outJson["cachedMsgMinOffset"], "0");
   EXPECT_EQ(outJson["cachedMsgMaxOffset"], "0");
   EXPECT_EQ(outJson["cachedMsgCount"].asInt(), 0);
@@ -67,6 +68,16 @@ TEST(processQueueInfo, init) {
   EXPECT_EQ(outJson["droped"].asBool(), true);
   EXPECT_EQ(outJson["lastPullTimestamp"], "0");
   EXPECT_EQ(outJson["lastConsumeTimestamp"], "0");
+
+  processQueueInfo.setCommitOffset(-1);
+  Json::Value sentinelJson = processQueueInfo.toJson();
+  EXPECT_TRUE(sentinelJson["commitOffset"].isInt64());
+  EXPECT_EQ(sentinelJson["commitOffset"].asInt64(), -1);
+
+  processQueueInfo.setCommitOffset(-2);
+  Json::Value exceptionalJson = processQueueInfo.toJson();
+  EXPECT_TRUE(exceptionalJson["commitOffset"].isInt64());
+  EXPECT_EQ(exceptionalJson["commitOffset"].asInt64(), -2);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
## What is the purpose of the change

- Fixes #511 

commitOffset 有可能为 -1/-2, 此时由于 uint64, 赋值时会溢出，从而设置为一个非常大的数，当 RocketMQ 服务端请求 GetRunningInfo 接口时会出现 Gson 解析错误，原因是超过了 long 的最大值，导致该接口请求失败。最终影响订阅一致性的判断以及客户端运行中信息的获取。当使用新订阅组时一定会遇到该问题，且消费一段时间后重启，因为重试队列还没提交位点，因此该接口还是会报错。

The commitOffset could be -1 or -2. Since it's a uint64, this could overflow during assignment, resulting in a very large number. When the RocketMQ server requests the GetRunningInfo interface, a Gson parsing error will occur because the value exceeds the long threshold, causing the request to fail. Ultimately, this affects the consistency of the subscription.This issue will definitely occur when using a new subscription group.

Python SDK 底层会依赖 CPP， 因此 ERROR:
<img width="1280" height="525" alt="image" src="https://github.com/user-attachments/assets/a4ea978f-3a40-412f-a74e-b5dc2b710eb2" />


## Brief changelog

update uint64 to int64

## Verifying this change


